### PR TITLE
docs: add contributing guide code ownership and pr template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,62 @@
+# CODEOWNERS — Auto-asignacion de reviewers por modulo
+# Doc: https://docs.github.com/en/repositories/managing-your-repositories-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Reglas:
+# - El ultimo patron que matchee gana.
+# - Toda PR que toque la ruta auto-asigna a los owners listados.
+# - Branch protection con "require_code_owner_reviews=true" bloquea merge sin approval del owner.
+#
+# Nick @JuliCriollo por confirmar. Actualizar cuando se valide.
+
+# ============ DOCUMENTACION GENERAL ============
+*                                                              @13rianVargas
+
+# ============ TALLERES (academicos) ============
+/Taller-3/                                                     @13rianVargas
+/Taller-4/                                                     @13rianVargas
+/Taller-5/                                                     @13rianVargas
+/Taller-6/                                                     @13rianVargas
+/Taller-7/                                                     @13rianVargas
+/PSP-TSP-Expo/                                                 @13rianVargas
+/Scrum-Backlog/                                                @13rianVargas
+
+# ============ PROYECTO-FINAL ============
+
+# Database — Brian
+/Proyecto-Final/database/                                      @13rianVargas
+
+# Backend — Juli Criollo
+/Proyecto-Final/backend/                                       @JuliCriollo
+
+# Frontend Web — Santi
+/Proyecto-Final/frontend/pqrs-app/src/app/web/                 @SantiagoRR17
+
+# Frontend Mobile — Juli Avila
+/Proyecto-Final/frontend/pqrs-app/src/app/mobile/              @JulianAvila259
+
+# Frontend compartido — review obligatoria de ambos
+/Proyecto-Final/frontend/pqrs-app/src/app/core/                @SantiagoRR17 @JulianAvila259
+/Proyecto-Final/frontend/pqrs-app/src/app/shared/              @SantiagoRR17 @JulianAvila259
+/Proyecto-Final/frontend/pqrs-app/src/theme/                   @SantiagoRR17 @JulianAvila259
+/Proyecto-Final/frontend/pqrs-app/src/environments/            @SantiagoRR17 @JulianAvila259
+
+# Frontend config root — review ambos
+/Proyecto-Final/frontend/pqrs-app/package.json                 @SantiagoRR17 @JulianAvila259
+/Proyecto-Final/frontend/pqrs-app/pnpm-lock.yaml               @SantiagoRR17 @JulianAvila259
+/Proyecto-Final/frontend/pqrs-app/pnpm-workspace.yaml          @SantiagoRR17 @JulianAvila259
+/Proyecto-Final/frontend/pqrs-app/angular.json                 @SantiagoRR17 @JulianAvila259
+/Proyecto-Final/frontend/pqrs-app/tsconfig*.json               @SantiagoRR17 @JulianAvila259
+/Proyecto-Final/frontend/pqrs-app/.eslintrc.json               @SantiagoRR17 @JulianAvila259
+/Proyecto-Final/frontend/pqrs-app/tailwind.config.js           @SantiagoRR17 @JulianAvila259
+/Proyecto-Final/frontend/pqrs-app/karma.conf.js                @SantiagoRR17 @JulianAvila259
+
+# Docs Proyecto-Final — Brian
+/Proyecto-Final/docs/                                          @13rianVargas
+/Proyecto-Final/*.md                                           @13rianVargas
+
+# ============ INFRA DEL REPO ============
+/.github/                                                      @13rianVargas
+/Proyecto-Final/.github/                                       @13rianVargas
+/.gitignore                                                    @13rianVargas
+/AGENTS.md                                                     @13rianVargas
+/CLAUDE.md                                                     @13rianVargas

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Guia de contribucion — Repositorio academico
+
+Este repositorio contiene:
+
+- **Talleres 3–7**: artefactos academicos entregados (Scrum, arquitectura, plan pruebas).
+- **PSP-TSP-Expo**: material de exposicion.
+- **Proyecto-Final**: implementacion del sistema PQRS.
+
+Para reglas de la implementacion (commits, ramas, CI, ownership) ver [`Proyecto-Final/.github/CONTRIBUTING.md`](../Proyecto-Final/.github/CONTRIBUTING.md).
+
+---
+
+## Reglas globales del repositorio
+
+### Lenguaje y formato
+
+- Documentacion en **espanol**.
+- Sin emojis en markdown tecnico.
+- Markdown plano, sin HTML embedido cuando se pueda evitar.
+
+### Commits
+
+- **Conventional Commits sin scopes**. Detalle completo en `Proyecto-Final/.github/CONTRIBUTING.md`.
+- Mensajes en **ingles, minusculas, sin punto final**.
+- **Nunca atribuir IA** en commits (`Co-Authored-By: Claude`, etc. estan prohibidos).
+- Conventional Commits en titulos de PR — validado por `commitlint` workflow.
+
+### Talleres (artefactos academicos)
+
+- Numeracion de archivos (`0-`, `1-`, `3.1-`) define orden de lectura. **No renumerar al insertar**.
+- Diagramas: editar fuente (`.puml` / `.d2`), no solo el PNG.
+- Casos de uso: ID y nombre sincronizados con `0-Resumen-Casos-Uso.md`.
+- Cuando una HU/CU/RNF se toque, verificar referencias cruzadas (backlog, RNF, mockup, diagramas).
+- Contexto fuente (`Contexto-Talleres.md`): no editar sin permiso.
+
+### Archivos prohibidos en el repo
+
+- Lockfiles npm/yarn (`package-lock.json`, `yarn.lock`) — solo `pnpm-lock.yaml`.
+- Exportaciones Word (`*.htm`, `*_archivos/`, `*.doc`) — usar Markdown o PDF.
+- Scripts sueltos en raiz (poner en su modulo).
+- Credenciales o secretos.
+
+`.gitignore` raiz bloquea los patrones de arriba.
+
+### Pull Requests
+
+- Plantilla en `.github/pull_request_template.md`.
+- 1 aprobacion minimo de owner del modulo.
+- CI obligatorio (lint + tests + build + commitlint) para PRs que tocan `Proyecto-Final/`.
+
+### Issues
+
+- Plantillas en `.github/ISSUE_TEMPLATE/`:
+  - `test-case.yml`: casos de prueba (Taller-7 y Proyecto-Final).
+  - `bug-report.yml`: reporte de bugs.
+
+### Ownership
+
+Ver `Proyecto-Final/.github/CONTRIBUTING.md` seccion 5 y `.github/CODEOWNERS`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,44 @@
+<!--
+Plantilla universal para PRs del repositorio.
+Lee la guia: Proyecto-Final/.github/CONTRIBUTING.md
+-->
+
+## Tipo de cambio
+
+- [ ] feat — nueva funcionalidad
+- [ ] fix — correccion de bug
+- [ ] chore — mantenimiento (deps, CI, configs)
+- [ ] docs — documentacion
+- [ ] refactor — sin cambiar comportamiento
+- [ ] test — agregar o modificar tests
+- [ ] hotfix — urgente en produccion
+- [ ] release — preparacion de version
+
+## Descripcion
+
+<!-- Que cambia y por que. Sin redundar con el titulo. -->
+
+## Issue relacionado
+
+<!-- Closes #N — si aplica. -->
+
+## Checklist obligatorio
+
+- [ ] Titulo del PR sigue Conventional Commits **sin scopes** (ej: `feat: add login`, no `feat(auth): add login`).
+- [ ] Rama nace de `develop` (excepto `hotfix/*` que nace de `main`).
+- [ ] Tests pasan localmente (`pnpm test` si toca frontend).
+- [ ] Lint sin errores (`pnpm run lint`).
+- [ ] Build pasa (`pnpm run build`).
+- [ ] Sin credenciales hardcoded ni secretos.
+- [ ] Sin `console.log` ni codigo comentado muerto.
+- [ ] CODEOWNERS auto-asigno reviewers correctos.
+- [ ] Capturas adjuntas si el PR toca UI.
+
+## Archivos compartidos
+
+- [ ] N/A — solo toca mi modulo.
+- [ ] Toca `core/`, `shared/`, `theme/`, `package.json`, `pnpm-lock.yaml` o `angular.json` → review de Santi + Juli Avila confirmada.
+
+## Notas para el reviewer
+
+<!-- Areas que necesitan atencion especial, decisiones de diseno, trade-offs. -->

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,6 @@ Taller-7/PlanDePruebas/plan-de-pruebas.docx
 *_archivos/
 *.doc
 *.docx
-!Taller-6/Arquitectura/**/*.pdf
-!Taller-7/PlanDePruebas/plan-de-pruebas.docx
 
 # Scripts sueltos prohibidos en raíz
 /update-mockups.js

--- a/Proyecto-Final/.github/AGENT.md
+++ b/Proyecto-Final/.github/AGENT.md
@@ -1,0 +1,55 @@
+# AGENT.md — Reglas para Claude dentro de Proyecto-Final
+
+Este archivo aplica solo a `Proyecto-Final/`. Reglas globales del repositorio: `AGENTS.md` raiz.
+
+## Antes de tocar codigo
+
+1. Leer [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+2. Identificar a que modulo pertenece el cambio (database, backend, frontend web, frontend mobile, core compartido).
+3. Verificar que el owner del modulo este enterado (en duda, preguntar al usuario).
+4. Si el cambio toca `core/`, `shared/`, `theme/` o config root del frontend: requiere coordinacion entre Santi y Juli Avila.
+
+## Reglas de commits
+
+- Conventional Commits **sin scopes**.
+- Ingles, minusculas, sin punto final.
+- Sin atribucion de IA (`Co-Authored-By: Claude` y similares estan prohibidos).
+- Un commit = un cambio logico. No mezclar refactor con feature.
+
+## Reglas de ramas
+
+- Nunca commit directo a `main` ni `develop`.
+- Crear rama segun tipo: `feature/*`, `bugfix/*`, `chore/*`, `docs/*`, `test/*`, `hotfix/*`, `release/*`.
+- PR siempre hacia `develop` (excepto `hotfix/*` y `release/*` que van a ambos).
+
+## Stack y herramientas
+
+- Package manager: **pnpm only**. Nunca correr `npm install` ni `yarn install`.
+- Frontend: Angular 20 + Ionic 8 + Tailwind.
+- Backend: Spring Boot 3.x + Java 17 + Maven.
+- DB: PostgreSQL 15 + Flyway.
+- Tests front: Karma + Jasmine (default Ionic).
+- Lint front: ESLint via `pnpm run lint`.
+
+## Verificaciones automaticas
+
+- `commitlint` valida titulo del PR — falla si lleva scope.
+- `frontend-ci` corre lint + Karma + ng build en PRs que tocan `frontend/`.
+- `backend-ci` corre Maven verify cuando exista `pom.xml`.
+- Husky pre-commit local corre `lint-staged` (lint + auto-fix).
+- Husky commit-msg local valida convencion.
+
+## Dominio
+
+**PQRS — Peticiones, Quejas, Reclamos, Sugerencias.**
+
+Fuente: `Proyecto-Final/1-Funcionalidades.md`. Talleres 6/7 trabajaron sobre E-Commerce Konrad como guia. Sus artefactos se portan a PQRS dentro de `Proyecto-Final/docs/`. Los talleres no se modifican.
+
+## Prohibido
+
+- Implementar codigo de otros modulos sin que el owner lo apruebe.
+- Commitear lockfiles npm/yarn.
+- Commitear archivos Office (`.htm`, `.doc`, `.docx`).
+- Modificar talleres ya entregados sin instruccion explicita del usuario.
+- Crear archivos nuevos en raiz del repo (deben ir dentro de un modulo).
+- Sumar dependencias al frontend sin avisar — package manager dual rompe lockfile.

--- a/Proyecto-Final/.github/CONTRIBUTING.md
+++ b/Proyecto-Final/.github/CONTRIBUTING.md
@@ -1,0 +1,338 @@
+# Guia de contribucion — Proyecto-Final (PQRS)
+
+Este documento aplica a todo el codigo dentro de `Proyecto-Final/`. Para reglas globales del repositorio academico (talleres, documentacion general) ver [`.github/CONTRIBUTING.md`](../../.github/CONTRIBUTING.md) en la raiz.
+
+Inspirado en la guia de K-Forge.
+
+---
+
+## 1. Dominio del proyecto
+
+**PQRS — Peticiones, Quejas, Reclamos y Sugerencias.**
+
+Fuente oficial: [`Proyecto-Final/1-Funcionalidades.md`](../1-Funcionalidades.md).
+
+Los Talleres 6 y 7 trabajaron sobre un caso de estudio diferente (E-Commerce Konrad) como guia metodologica. Sus artefactos se portan al dominio PQRS dentro de `Proyecto-Final/docs/`. Los talleres no se modifican.
+
+---
+
+## 2. Stack tecnologico
+
+| Capa | Tecnologia |
+|---|---|
+| Frontend Web y Mobile | Angular 20 + Ionic 8 + Tailwind CSS |
+| Backend | Java OpenJDK 17 + Spring Boot 3.x |
+| Base de Datos | PostgreSQL 15+ |
+| Migraciones DB | Flyway |
+| Seguridad | BCrypt + JWT + HTTPS |
+| Package manager (frontend) | **pnpm — npm prohibido** |
+| Build backend | Maven |
+
+---
+
+## 3. Convencion para commits
+
+Seguimos **Conventional Commits**. Formato:
+
+```
+type: short message in english
+```
+
+> Mensaje siempre en **ingles**, **minusculas**, sin punto final. **NO usar scopes entre parentesis.**
+
+### Tipos validos
+
+| Tipo | Descripcion |
+|---|---|
+| `feat` | Nueva funcionalidad |
+| `fix` | Correccion de errores |
+| `chore` | Mantenimiento (deps, configs, tooling) |
+| `release` | Preparacion de version |
+| `hotfix` | Correccion urgente en produccion |
+| `docs` | Cambios en documentacion |
+| `refactor` | Refactor sin cambiar comportamiento |
+| `test` | Agregar o modificar tests |
+
+### Ejemplos correctos
+
+```
+feat: add login screen for mobile
+fix: resolve jwt token expiration bug
+chore: update spring boot dependencies
+docs: add branching guide to contributing
+refactor: extract user validation logic
+test: add integration tests for pqrs service
+release: prepare version 1.0.0
+hotfix: fix cors config in gateway
+```
+
+### Ejemplos incorrectos (con casos reales del repo)
+
+| Ejemplo | Problema |
+|---|---|
+| `update` | No describe nada util |
+| `cambios` | Ambiguo y no en ingles |
+| `FEAT: Add product` | No usar mayusculas |
+| `feat(agregacion): implementar login` | **No usar scopes** |
+| `feat(frontend): migrate to pnpm` | **No usar scopes** |
+| `feat: Add Product.` | No usar mayusculas ni punto final |
+| `fix: fixed the bug` | Vago — que bug, donde |
+
+Validacion automatica: `commitlint` corre en cada PR (config en [`.github/commitlint.config.js`](./commitlint.config.js)).
+
+---
+
+## 4. Estrategia de ramas — Git Flow
+
+Casi todo sale de `develop`. Solo `hotfix/*` sale de `main`.
+
+```mermaid
+gitGraph
+   commit id: "init"
+   branch develop
+   checkout develop
+   commit id: "setup"
+   branch feature/login
+   checkout feature/login
+   commit id: "feat: add login"
+   checkout develop
+   merge feature/login
+   branch release/1.0.0
+   checkout release/1.0.0
+   checkout main
+   merge release/1.0.0 tag: "v1.0.0"
+   checkout develop
+   merge release/1.0.0
+   checkout main
+   branch hotfix/fix-cors
+   checkout hotfix/fix-cors
+   commit id: "hotfix: fix cors"
+   checkout main
+   merge hotfix/fix-cors tag: "v1.0.1"
+   checkout develop
+   merge hotfix/fix-cors
+```
+
+### Tipos de rama
+
+| Rama | Para que | Crear desde | PR hacia | Eliminar |
+|---|---|---|---|---|
+| `main` | Codigo estable produccion | — | — | Nunca |
+| `develop` | Integracion diaria | `main` | `main` (via release) | Nunca |
+| `feature/*` | Nueva funcionalidad | `develop` | `develop` | Tras merge |
+| `bugfix/*` | Bug no urgente | `develop` | `develop` | Tras merge |
+| `chore/*` | Docs, CI/CD, deps, configs | `develop` | `develop` | Tras merge |
+| `test/*` | Pruebas tecnicas | `develop` | `develop` (si aplica) | Tras merge o descartar |
+| `release/*` | Preparar version | `develop` | `main` y `develop` | Tras merge a ambos |
+| `hotfix/*` | Incidente urgente | `main` | `main` y `develop` | Tras merge a ambos |
+
+### Nombres de rama
+
+Formato: `<tipo>/<descripcion-en-kebab-case>`.
+
+```
+feature/database-schema-init
+feature/auth-jwt-backend
+bugfix/fix-radicar-validation
+chore/update-angular-deps
+hotfix/fix-cors-gateway
+release/1.2.0
+test/pqrs-service-integration
+```
+
+Incorrectos: `feat/login`, `mi-rama`, `feature/StudentDash`, `feature/changes`.
+
+### Workflow minimo
+
+```bash
+# 1. Sincronizar develop
+git checkout develop && git pull origin develop
+
+# 2. Crear rama
+git checkout -b feature/nombre-descriptivo
+
+# 3. Commits atomicos
+git add .
+git commit -m "feat: add pqrs status filter"
+
+# 4. Push y PR hacia develop
+git push -u origin feature/nombre-descriptivo
+gh pr create --base develop --fill
+```
+
+Para `release/*` y `hotfix/*`: abrir PR a `main` Y a `develop`.
+
+---
+
+## 5. Mapa de ownership
+
+Cada modulo tiene responsable principal. `CODEOWNERS` auto-asigna reviewers.
+
+| Persona | Modulo | Ruta |
+|---|---|---|
+| Brian Vargas (`@13rianVargas`) | Database + comodin | `Proyecto-Final/database/` |
+| Juli Criollo (`@JuliCriollo`) | Backend (Spring Boot) | `Proyecto-Final/backend/` |
+| Santiago RR (`@SantiagoRR17`) | Frontend Web | `Proyecto-Final/frontend/pqrs-app/src/app/web/` |
+| Juli Avila (`@JulianAvila259`) | Frontend Mobile | `Proyecto-Final/frontend/pqrs-app/src/app/mobile/` |
+
+> Nick `@JuliCriollo` por confirmar. Ajustar en `.github/CODEOWNERS` cuando se valide.
+
+### Archivos compartidos (review obligatoria de Santi + Juli Avila)
+
+- `Proyecto-Final/frontend/pqrs-app/src/app/core/`
+- `Proyecto-Final/frontend/pqrs-app/src/app/shared/`
+- `Proyecto-Final/frontend/pqrs-app/src/theme/`
+- `Proyecto-Final/frontend/pqrs-app/package.json`
+- `Proyecto-Final/frontend/pqrs-app/pnpm-lock.yaml`
+- `Proyecto-Final/frontend/pqrs-app/angular.json`
+
+### Regla de oro
+
+Si tu PR toca codigo fuera de tu modulo asignado: solicita revision al owner antes de mergear, aunque CODEOWNERS no lo bloquee.
+
+---
+
+## 6. Versionamiento — SemVer
+
+Formato `MAJOR.MINOR.PATCH`.
+
+| Segmento | Cuando incrementar | Ejemplo |
+|---|---|---|
+| `MAJOR` | Cambios incompatibles | `1.0.0` → `2.0.0` |
+| `MINOR` | Funcionalidad compatible | `1.0.0` → `1.1.0` |
+| `PATCH` | Correcciones produccion | `1.1.0` → `1.1.1` |
+
+Pre-release:
+
+```
+0.1.0-alpha.1    primera iteracion
+0.1.0-beta.1     pruebas
+0.1.0            stable
+```
+
+---
+
+## 7. Pull Requests
+
+- Titulo: convencion de commits, sin scope.
+- Descripcion: usar plantilla `.github/pull_request_template.md`.
+- Vincular issue si existe (`Closes #N`).
+- Codigo debe pasar lint + tests + build (CI obligatorio).
+- Al menos **1 aprobacion** de owner del modulo.
+- Toca archivos compartidos? Confirmar review de ambos frontend devs.
+- Branch protection bloquea merge si checks fallan.
+
+---
+
+## 8. Estandares de codigo
+
+### TypeScript / Angular
+
+| Elemento | Convencion |
+|---|---|
+| Clases, componentes | PascalCase |
+| Metodos, funciones, variables | camelCase |
+| Constantes | UPPER_SNAKE_CASE |
+| Modulos, archivos | kebab-case.ts |
+| Indentacion | 2 espacios |
+| Imports sin usar | Eliminar siempre |
+| `console.log` | Eliminar antes del PR |
+| `any` | Evitar — usar tipos especificos |
+| Credenciales | Nunca en codigo — usar `environment.ts` con valores dummy |
+
+ESLint config: `Proyecto-Final/frontend/pqrs-app/.eslintrc.json`. Corre `pnpm run lint` antes de commit.
+
+### Java / Spring Boot
+
+| Elemento | Convencion |
+|---|---|
+| Clases | PascalCase |
+| Metodos, variables | camelCase |
+| Constantes | UPPER_SNAKE_CASE |
+| Paquetes | minusculas, sin guiones |
+| Indentacion | 4 espacios |
+| Anotaciones lombok | OK si reducen boilerplate |
+| Credenciales | `application.yml` con perfiles + `.env` |
+
+### SQL / Migraciones Flyway
+
+- Archivos: `V{n}__descripcion_corta.sql` (snake_case).
+- Una migracion = un cambio logico.
+- Nunca editar migracion ya mergeada — crear nueva.
+- Comentar tablas y columnas no obvias.
+
+---
+
+## 9. Package manager — pnpm only
+
+Este repo **prohibe npm y yarn**. Solo `pnpm`.
+
+Razones:
+- Velocidad y eficiencia de disco (symlinks + content-addressable store).
+- Workspace nativo.
+- Seguridad: `onlyBuiltDependencies` controla scripts.
+
+Enforcement:
+- `package.json` tiene `"preinstall": "npx only-allow pnpm"` — corre `npm install` falla.
+- `.gitignore` bloquea `package-lock.json` y `yarn.lock`.
+
+Instalacion local:
+
+```bash
+npm install -g pnpm@9    # una sola vez
+cd Proyecto-Final/frontend/pqrs-app
+pnpm install
+pnpm start
+```
+
+Si llegas de npm: borrar `node_modules/` y `package-lock.json` antes de `pnpm install`.
+
+---
+
+## 10. Branch protection (admin)
+
+Configurar via GitHub UI (Settings → Branches → Add rule) o `gh api`:
+
+```bash
+# main
+gh api -X PUT /repos/13rianVargas/Ingenieria-de-Software-1/branches/main/protection \
+  -F required_status_checks.strict=true \
+  -F 'required_status_checks.contexts[]=frontend-ci' \
+  -F 'required_status_checks.contexts[]=commitlint' \
+  -F required_pull_request_reviews.required_approving_review_count=1 \
+  -F required_pull_request_reviews.dismiss_stale_reviews=true \
+  -F required_pull_request_reviews.require_code_owner_reviews=true \
+  -F enforce_admins=false \
+  -F allow_force_pushes=false \
+  -F allow_deletions=false \
+  -F restrictions=null
+
+# develop — mismo set
+gh api -X PUT /repos/13rianVargas/Ingenieria-de-Software-1/branches/develop/protection \
+  -F required_status_checks.strict=true \
+  -F 'required_status_checks.contexts[]=frontend-ci' \
+  -F 'required_status_checks.contexts[]=commitlint' \
+  -F required_pull_request_reviews.required_approving_review_count=1 \
+  -F required_pull_request_reviews.dismiss_stale_reviews=true \
+  -F required_pull_request_reviews.require_code_owner_reviews=true \
+  -F enforce_admins=false \
+  -F allow_force_pushes=false \
+  -F allow_deletions=false \
+  -F restrictions=null
+```
+
+Activar solo despues de mergear los workflows CI (sino los status checks no existen y bloquean todo).
+
+---
+
+## 11. Reporte de bugs
+
+Abrir Issue con plantilla `.github/ISSUE_TEMPLATE/bug-report.yml`. Incluir:
+
+- Descripcion del problema.
+- Pasos para reproducir.
+- Comportamiento esperado vs actual.
+- Capturas si aplica.
+- Ambiente (browser, OS, version).
+
+Casos de prueba: plantilla `.github/ISSUE_TEMPLATE/test-case.yml` (de Taller-7).


### PR DESCRIPTION
## Summary

- Add `Proyecto-Final/.github/CONTRIBUTING.md` adapted from K-Forge (no scopes, git flow, PQRS domain, pnpm-only)
- Add `.github/CONTRIBUTING.md` root with global repo rules
- Add `.github/pull_request_template.md` with universal checklist
- Add `.github/CODEOWNERS` mapping modules to owners
- Add `Proyecto-Final/.github/AGENT.md` rules for Claude
- Fix `.gitignore` (remove incorrect docx exceptions that broke generated-file ignore)

## Why

Repo had zero formal conventions. Teammates already committed with bad scopes (`feat(agregacion):`, `feat(frontend):`) and pisa-ownership. This locks down:

- Commit format validated by `commitlint` (next PR)
- Branch protection mapped to status checks (next PR)
- Owner auto-assignment via CODEOWNERS
- Single source of truth for stack decisions (pnpm-only, PQRS domain, Git Flow)

## Ownership map

| Person | Module |
|---|---|
| `@13rianVargas` | Database + repo infra |
| `@JuliCriollo` (nick TBC) | Backend (Spring Boot) |
| `@SantiagoRR17` | Frontend Web |
| `@JulianAvila259` | Frontend Mobile |

Shared (`core/`, `shared/`, `theme/`, config root): review by both frontend devs.

## Test plan

- [ ] Open this PR — verify CODEOWNERS auto-assigns @13rianVargas (touches `/.github/`)
- [ ] Open a test PR with title `feat(scope): something` — should be flagged once commitlint workflow lands (next PR)
- [ ] Verify rendered markdown of CONTRIBUTING.md is readable on GitHub

## Pending

- Confirm Juli Criollo GitHub nick — placeholder `@JuliCriollo` in CODEOWNERS
- Next PR: CI workflows (frontend-ci, commitlint, backend-ci placeholder)
- After CI merged: configure branch protection on main + develop