### PR TITLE
fix: backend-ci placeholder reports success when pom.xml absent

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,19 +1,13 @@
 name: backend-ci
 
-# Placeholder workflow. Auto-corre Maven verify cuando exista
-# Proyecto-Final/backend/pom.xml. Mientras tanto reporta success.
+# Workflow corre siempre. Detecta si existe pom.xml para decidir.
+# Cuando backend dev cree Proyecto-Final/backend/pom.xml, Maven verify activa.
 
 on:
   pull_request:
     branches: [main, develop]
-    paths:
-      - 'Proyecto-Final/backend/**'
-      - '.github/workflows/backend-ci.yml'
   push:
     branches: [main, develop]
-    paths:
-      - 'Proyecto-Final/backend/**'
-      - '.github/workflows/backend-ci.yml'
 
 concurrency:
   group: backend-ci-${{ github.ref }}

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,7 +1,7 @@
 name: backend-ci
 
-# Placeholder — activar cuando Proyecto-Final/backend/pom.xml exista.
-# Para activar: cambiar el `if: false` por la condicion real y removerlo.
+# Placeholder workflow. Auto-corre Maven verify cuando exista
+# Proyecto-Final/backend/pom.xml. Mientras tanto reporta success.
 
 on:
   pull_request:
@@ -20,20 +20,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  check:
     name: maven verify
     runs-on: ubuntu-latest
-    # Cambiar a `true` cuando exista pom.xml. Mientras tanto skip silencioso.
-    if: ${{ hashFiles('Proyecto-Final/backend/pom.xml') != '' }}
-    defaults:
-      run:
-        working-directory: Proyecto-Final/backend
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Detect backend
+        id: detect
+        run: |
+          if [ -f Proyecto-Final/backend/pom.xml ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Backend pom.xml not found yet — placeholder success."
+          fi
+
       - name: Setup Java
+        if: steps.detect.outputs.exists == 'true'
         uses: actions/setup-java@v4
         with:
           java-version: '17'
@@ -41,4 +46,6 @@ jobs:
           cache: maven
 
       - name: Maven verify
+        if: steps.detect.outputs.exists == 'true'
+        working-directory: Proyecto-Final/backend
         run: mvn -B verify

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -3,14 +3,8 @@ name: frontend-ci
 on:
   pull_request:
     branches: [main, develop]
-    paths:
-      - 'Proyecto-Final/frontend/**'
-      - '.github/workflows/frontend-ci.yml'
   push:
     branches: [main, develop]
-    paths:
-      - 'Proyecto-Final/frontend/**'
-      - '.github/workflows/frontend-ci.yml'
 
 concurrency:
   group: frontend-ci-${{ github.ref }}
@@ -27,13 +21,36 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect frontend changes
+        id: detect
+        working-directory: ${{ github.workspace }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_SHA=$(git merge-base origin/${{ github.base_ref }} HEAD)
+          else
+            BASE_SHA=$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)
+          fi
+          CHANGED=$(git diff --name-only "$BASE_SHA" HEAD)
+          echo "Changed files:"
+          echo "$CHANGED"
+          if echo "$CHANGED" | grep -qE '^Proyecto-Final/frontend/|^\.github/workflows/frontend-ci\.yml$'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "No frontend changes detected — placeholder success."
+          fi
 
       - name: Setup pnpm
+        if: steps.detect.outputs.run == 'true'
         uses: pnpm/action-setup@v4
         with:
           version: 9
 
       - name: Setup Node
+        if: steps.detect.outputs.run == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -41,13 +58,17 @@ jobs:
           cache-dependency-path: Proyecto-Final/frontend/pqrs-app/pnpm-lock.yaml
 
       - name: Install dependencies
+        if: steps.detect.outputs.run == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Lint
+        if: steps.detect.outputs.run == 'true'
         run: pnpm run lint
 
       - name: Unit tests (Karma headless)
+        if: steps.detect.outputs.run == 'true'
         run: pnpm test -- --watch=false --browsers=ChromeHeadless --code-coverage=false
 
       - name: Build
+        if: steps.detect.outputs.run == 'true'
         run: pnpm run build


### PR DESCRIPTION
## Summary

Backend-ci workflow was failing on every PR because no jobs were runnable (job-level `if:` evaluated false, GitHub marks it as failure).

## Fix

Job always runs. Detects `Proyecto-Final/backend/pom.xml` in a step. If absent: reports success placeholder. If present: runs Maven verify.

## Why

Needed before branch protection. Cannot require a status check that always fails.

## Test plan

- [ ] This PR should show backend-ci as success (no pom.xml exists)
- [ ] When backend dev creates pom.xml, workflow auto-activates Maven verify