### PR TITLE
fix: parse neon url into jdbc + credentials for flyway

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -4,7 +4,11 @@ name: db-migrate
 # Tambien disparable manual desde GitHub UI (Actions tab → db-migrate → Run workflow).
 #
 # Requisito: GitHub Secret DATABASE_URL_DIRECT con connection string Neon
-# (rol neondb_owner, endpoint SIN -pooler, sslmode=require).
+# en formato libpq: postgresql://USER:PASS@HOST/DB?sslmode=require
+# (rol neondb_owner, endpoint SIN -pooler).
+#
+# El workflow extrae user/password de la URL y construye el JDBC URL
+# (Flyway no acepta credenciales embebidas en la URL).
 
 on:
   push:
@@ -36,17 +40,26 @@ jobs:
           tar xzf flyway.tgz
           echo "$PWD/flyway-10.20.1" >> "$GITHUB_PATH"
 
-      - name: Validate
+      - name: Parse Neon URL into JDBC + credentials
         env:
           DATABASE_URL_DIRECT: ${{ secrets.DATABASE_URL_DIRECT }}
-        run: flyway -configFiles=flyway.conf -url="$DATABASE_URL_DIRECT" validate
+        run: |
+          URL="$DATABASE_URL_DIRECT"
+          DB_USER=$(echo "$URL" | sed -E 's|^postgres(ql)?://([^:]+):.*|\2|')
+          DB_PASS=$(echo "$URL" | sed -E 's|^postgres(ql)?://[^:]+:([^@]+)@.*|\2|')
+          HOSTDB=$(echo "$URL" | sed -E 's|^postgres(ql)?://[^@]+@(.*)$|\2|')
+          echo "::add-mask::$DB_PASS"
+          {
+            echo "FLYWAY_URL=jdbc:postgresql://$HOSTDB"
+            echo "FLYWAY_USER=$DB_USER"
+            echo "FLYWAY_PASSWORD=$DB_PASS"
+          } >> "$GITHUB_ENV"
+
+      - name: Validate
+        run: flyway -configFiles=flyway.conf validate
 
       - name: Migrate
-        env:
-          DATABASE_URL_DIRECT: ${{ secrets.DATABASE_URL_DIRECT }}
-        run: flyway -configFiles=flyway.conf -url="$DATABASE_URL_DIRECT" migrate
+        run: flyway -configFiles=flyway.conf migrate
 
       - name: Info
-        env:
-          DATABASE_URL_DIRECT: ${{ secrets.DATABASE_URL_DIRECT }}
-        run: flyway -configFiles=flyway.conf -url="$DATABASE_URL_DIRECT" info
+        run: flyway -configFiles=flyway.conf info

--- a/Proyecto-Final/database/README.md
+++ b/Proyecto-Final/database/README.md
@@ -102,12 +102,18 @@ psql "$DATABASE_URL_DIRECT" -c "TRUNCATE auditoria, notificacion, adjunto, trami
 
 ### (Opcional) Correr Flyway local para troubleshoot
 
-Solo si necesitas debugear una migracion fallida sin esperar al CI:
+Solo si necesitas debugear una migracion fallida sin esperar al CI. Flyway no acepta credenciales embebidas en URL, hay que parsear primero:
 
 ```bash
 brew install flyway      # macOS
 cd Proyecto-Final/database
-source .env              # con DATABASE_URL_DIRECT
+
+# Parsear .env (formato libpq) a vars Flyway
+URL="$DATABASE_URL_DIRECT"
+export FLYWAY_USER=$(echo "$URL" | sed -E 's|^postgres(ql)?://([^:]+):.*|\2|')
+export FLYWAY_PASSWORD=$(echo "$URL" | sed -E 's|^postgres(ql)?://[^:]+:([^@]+)@.*|\2|')
+export FLYWAY_URL="jdbc:postgresql://$(echo "$URL" | sed -E 's|^postgres(ql)?://[^@]+@(.*)$|\2|')"
+
 flyway -configFiles=flyway.conf migrate
 ```
 

--- a/Proyecto-Final/database/flyway.conf
+++ b/Proyecto-Final/database/flyway.conf
@@ -1,14 +1,20 @@
 # Flyway CLI config — Proyecto-Final database
 # Doc: https://documentation.red-gate.com/fd/parameters-184127446.html
 #
-# Uso:
-#   export DATABASE_URL_DIRECT="postgresql://neondb_owner:PASS@ep-xxx.neon.tech/neondb?sslmode=require"
+# Uso CI:
+#   El workflow .github/workflows/db-migrate.yml parsea DATABASE_URL_DIRECT
+#   (formato libpq) y exporta FLYWAY_URL, FLYWAY_USER, FLYWAY_PASSWORD.
+#   Flyway los recoge automaticamente.
+#
+# Uso local (Brian, troubleshoot):
+#   export FLYWAY_URL="jdbc:postgresql://ep-xxx.neon.tech/neondb?sslmode=require"
+#   export FLYWAY_USER="neondb_owner"
+#   export FLYWAY_PASSWORD="..."
 #   flyway -configFiles=flyway.conf migrate
 #
 # Las migraciones viven en ./migrations relativo a este archivo.
 # Solo el owner de la BD (Brian con neondb_owner) corre migraciones.
 
-flyway.url=${DATABASE_URL_DIRECT}
 flyway.locations=filesystem:./migrations
 flyway.encoding=UTF-8
 


### PR DESCRIPTION
## Summary

PR #28 mergeo OK pero el workflow `db-migrate` fallo en step Validate con `No database found to handle ***`.

Causa: Neon entrega connection string en formato libpq (`postgresql://user:pass@host/db`), pero Flyway necesita JDBC (`jdbc:postgresql://host/db`) + user/password separados.

## Fix

- `db-migrate.yml`: nuevo step `Parse Neon URL` extrae user/pass via sed, exporta `FLYWAY_URL`, `FLYWAY_USER`, `FLYWAY_PASSWORD` (Flyway los recoge automatico). Mask del password con `::add-mask::`.
- `flyway.conf`: removido `flyway.url=${DATABASE_URL_DIRECT}` (interpolaba libpq). Ahora el workflow inyecta el URL JDBC correcto via env.
- `README.md`: actualizada seccion troubleshoot local con mismo parsing.

## Test plan

Al mergear este PR el workflow `db-migrate` se dispara de nuevo (el path filter `.github/workflows/db-migrate.yml` esta listado). Esperado:

- [ ] Step `Parse Neon URL` exporta vars OK (sin leakar pass en logs).
- [ ] Step `Validate` pasa.
- [ ] Step `Migrate` reporta `Successfully applied 5 migrations`.
- [ ] Step `Info` muestra V1–V5 en estado `Success`.