### PR TITLE
fix: remove redundant flyway validate step before migrate

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -55,9 +55,6 @@ jobs:
             echo "FLYWAY_PASSWORD=$DB_PASS"
           } >> "$GITHUB_ENV"
 
-      - name: Validate
-        run: flyway -configFiles=flyway.conf validate
-
       - name: Migrate
         run: flyway -configFiles=flyway.conf migrate
 


### PR DESCRIPTION
## Summary

Segundo bug en `db-migrate.yml`: el step `Validate` corria ANTES de `Migrate`. En BD vacia (primer run) Flyway rechaza por `Detected resolved migration not applied to database: 1, 2, 3, 4, 5`.

## Fix

Removido step `Validate` independiente. El step `Migrate` ya tiene validacion interna via `flyway.validateOnMigrate=true` (default) — valida checksums DESPUES de aplicar, no antes.

## Test plan

Al mergear, workflow `db-migrate` corre solo `Migrate` + `Info`. Esperado:

- [ ] `Migrate` reporta `Successfully applied 5 migrations to schema "public"`.
- [ ] `Info` lista V1–V5 en estado `Success`.