### PR TITLE
docs: add pre-demo health check commands for db

### DIFF
--- a/Proyecto-Final/database/README.md
+++ b/Proyecto-Final/database/README.md
@@ -205,3 +205,67 @@ Resumen:
 - **Sin Docker local.** La BD es Neon compartida. Si necesitas desarrollo offline, monta tu propio Postgres y apunta `DATABASE_URL` ahi.
 - **Migraciones via GitHub Action.** Devs no instalan Flyway. Brian no aplica manual (excepto troubleshoot).
 - **`spring.flyway.enabled=false` en backend.** Evita race conditions cuando varios devs arrancan backend.
+
+---
+
+## Health checks pre-demo
+
+Ejecutar 5 min antes de la demo para **pre-warm de Neon** (free tier suspende compute tras 5 min inactivo) y **validar** que la BD tiene los datos esperados:
+
+```bash
+# 0. Pre-warm: primer query despierta el compute (~1-2 s primera vez)
+psql "$DATABASE_URL_DIRECT" -c "SELECT 1;"
+
+# 1. Conectividad + version Postgres
+psql "$DATABASE_URL_DIRECT" -c "SELECT version();"
+
+# 2. 4 usuarios demo presentes (brian, gestor, cliente, maria)
+psql "$DATABASE_URL_DIRECT" -c "SELECT count(*) AS total_usuarios FROM usuario;"
+
+# 3. 3 PQRS demo presentes
+psql "$DATABASE_URL_DIRECT" -c "SELECT count(*) AS total_pqrs FROM pqrs;"
+
+# 4. 1 tramite demo presente
+psql "$DATABASE_URL_DIRECT" -c "SELECT count(*) AS total_tramites FROM tramite;"
+
+# 5. Listar usuarios + roles (verificar hashes BCrypt cargados, NO placeholders)
+psql "$DATABASE_URL_DIRECT" -c "SELECT id, email, rol, LEFT(clave_hash, 7) AS bcrypt_prefix FROM usuario ORDER BY id;"
+
+# 6. Flyway aplico todas las migraciones
+psql "$DATABASE_URL_DIRECT" -c "SELECT version, description, success, installed_on FROM flyway_schema_history ORDER BY installed_rank;"
+
+# 7. Pre-warm pooled endpoint (el que usa el backend en Render)
+psql "$DATABASE_URL" -c "SELECT 1;"
+```
+
+**Salida esperada**:
+
+| Check | Esperado |
+|---|---|
+| `SELECT 1` directo | `1` |
+| `version()` | `PostgreSQL 15.x ... on x86_64-pc-linux-gnu` |
+| `total_usuarios` | `4` |
+| `total_pqrs` | `3` |
+| `total_tramites` | `1` |
+| `bcrypt_prefix` en todas las filas | `$2a$12$` (NUNCA `$2a$12$Dummy`) |
+| `flyway_schema_history` | 5 filas con `success = true` (V1..V5) |
+| `SELECT 1` pooled | `1` (compute despierto para backend Render) |
+
+**Si algo falla**:
+
+- `password authentication failed` → password rotada despues de tu ultimo `.env`. Pide nuevo `DATABASE_URL` a Brian por WhatsApp.
+- `total_usuarios = 0` → seeds no cargadas. Ejecutar: `psql "$DATABASE_URL_DIRECT" -f seeds/demo.sql`.
+- `bcrypt_prefix` contiene `Dummy...` → seeds tienen hashes placeholder. Recargar con `seeds/demo.sql` actualizado (commit `8f4e51e` ya tiene los hashes reales para clave `Demo2026!`).
+- `total_usuarios > 4` → BD tiene datos previos. Limpiar: `psql "$DATABASE_URL_DIRECT" -c "TRUNCATE auditoria, notificacion, adjunto, tramite, pqrs, usuario CASCADE;"` y recargar seeds.
+- Flyway con `success = false` o filas faltantes → workflow `db-migrate` fallo. Revisar logs en GitHub Actions tab → `db-migrate` → ultima ejecucion.
+
+**Tiempo total**: ~30 segundos cuando compute ya esta despierto, ~1-2 s primera query en cold start.
+
+**Credenciales demo** (seeds `Demo2026!`):
+
+| Email | Rol | Para que sirve |
+|---|---|---|
+| `brian@demo.com` | admin | Acceso completo de administracion |
+| `gestor@demo.com` | gestor | Login App Web → bandeja, tramitar, reportes |
+| `cliente@demo.com` | cliente | Login App Movil → radicar, historial |
+| `maria@demo.com` | cliente | Cliente alternativo con 1 PQRS asociada |


### PR DESCRIPTION
## Summary

Cierra **T-DB.5** del [`PLAN-DB.md`](Proyecto-Final/PLAN-DB.md) que quedó pendiente cuando se cerró PR #49 sin merge.

Suma sección **"Health checks pre-demo"** al final de `Proyecto-Final/database/README.md` con:

- 7 comandos `psql` para pre-warm Neon + validación.
- Tabla de salidas esperadas (counts + bcrypt prefix + Flyway history).
- Troubleshooting: passwords rotadas, seeds sin cargar, hashes placeholder, datos previos, Flyway fallido.
- Tabla de credenciales demo (4 usuarios seed con clave `Demo2026!`).

## Trazabilidad

- Owner: Brian (DB + Líder de Pruebas).
- Branch nueva limpia desde `develop` actual (rama anterior `feature/database-seeds` tenía duplicados visuales en log por el rebase del PR #47).
- Plan: `PLAN-DB.md` §T-DB.5.
- Definition of Done correspondiente queda ✅.

## Test plan

- [x] Sección "Health checks pre-demo" presente al final del README.
- [x] 7 comandos psql ejecutables como bloque copy-paste.
- [x] Tabla salidas esperadas + troubleshooting + credenciales demo.

## Notas

- Branch local + remota `feature/database-seeds` borradas (ya estaba mergeada vía PR #48 y el log tenía duplicados visuales por el force-push del PR #47).
- Develop está limpio: PRs #47 + #48 ya mergeados.