### PR TITLE
chore: add dependabot templates pr extension and deploy docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,44 @@
+name: 🚀 Feature Request
+description: Propuesta de nueva funcionalidad o mejora.
+labels: ["feature-request", "phase-2"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Antes de abrir, verifica que la feature no esté ya cubierta en los `PLAN-*.md` del Proyecto-Final.
+
+  - type: input
+    id: titulo
+    attributes:
+      label: Título breve
+      placeholder: "ej: Agregar filtro por fecha en bandeja"
+    validations:
+      required: true
+
+  - type: textarea
+    id: descripcion
+    attributes:
+      label: Descripción
+      placeholder: "¿Qué problema resuelve? ¿Cómo se ve la solución?"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: modulo
+    attributes:
+      label: Módulo afectado
+      options:
+        - backend
+        - frontend-web
+        - frontend-mobile
+        - database
+        - cicd
+        - docs
+    validations:
+      required: true
+
+  - type: textarea
+    id: criterios
+    attributes:
+      label: Criterios de aceptación
+      placeholder: "Dado X, cuando Y, entonces Z."

--- a/.github/ISSUE_TEMPLATE/user-story.yml
+++ b/.github/ISSUE_TEMPLATE/user-story.yml
@@ -1,0 +1,38 @@
+name: 📖 Historia de Usuario
+description: HU formato Connextra para el backlog.
+labels: ["user-story", "phase-2"]
+body:
+  - type: input
+    id: id
+    attributes:
+      label: ID (ej. HU-13)
+    validations:
+      required: true
+
+  - type: textarea
+    id: historia
+    attributes:
+      label: Historia de Usuario
+      value: |
+        **Como** <actor>,
+        **Quiero** <acción>,
+        **Para** <valor de negocio>.
+    validations:
+      required: true
+
+  - type: textarea
+    id: ca
+    attributes:
+      label: Criterios de Aceptación
+      placeholder: |
+        - Dado X, cuando Y, entonces Z.
+        - ...
+    validations:
+      required: true
+
+  - type: input
+    id: sp
+    attributes:
+      label: Estimación (Story Points)
+    validations:
+      required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/Proyecto-Final/backend/pqrs"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "backend"
+
+  - package-ecosystem: "npm"
+    directory: "/Proyecto-Final/frontend/pqrs-app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "frontend"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "cicd"
+
+  - package-ecosystem: "gradle"
+    directory: "/Proyecto-Final/frontend/pqrs-app/android"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "frontend-mobile"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,3 +42,16 @@ Lee la guia: Proyecto-Final/.github/CONTRIBUTING.md
 ## Notas para el reviewer
 
 <!-- Areas que necesitan atencion especial, decisiones de diseno, trade-offs. -->
+
+---
+
+## Fase 2 — Checklist específico
+
+- [ ] Mi cambio respeta lo definido en mi `PLAN-*.md` (sección referencia: ___).
+- [ ] No introduce hardcode de URLs/secrets (usa `environment.ts` o GH Secrets).
+- [ ] Si toca backend: cobertura JaCoCo ≥ 70 % (CI verifica).
+- [ ] Si toca frontend: build prod corre sin errores.
+- [ ] Si toca mobile: `cap sync android` corre sin errores.
+- [ ] Demo grabado o screenshot si el cambio afecta UI.
+- [ ] Daily WhatsApp avisado del PR.
+

--- a/Proyecto-Final/AGENTS.md
+++ b/Proyecto-Final/AGENTS.md
@@ -234,6 +234,14 @@ Los **10 TCs PF-native** sobre HU-01 Radicar PQRS están abiertos como issues #3
 
 **Timestamp de rotación**: 2026-05-24 11:44:37 — leak purgado, contraseñas rotadas en Neon.
 
+### 10.7 Kanban Fase 2
+
+**Board**: https://github.com/users/13rianVargas/projects/2 (PQRS Fase 2 — MVP Implementation).
+
+**Labels por área**: `phase-2` + uno de `backend`, `frontend-web`, `frontend-mobile`, `database`, `cicd`.
+
+**Issues T-X.Y**: #53–#92 cubren todas las tareas de los 5 planes. Owners en el body de cada issue. Cerrar al completar; PR debe referenciar `Closes #N` para auto-cierre.
+
 ---
 
 ## 11. Plataformas externas (Fase 2)

--- a/Proyecto-Final/AGENTS.md
+++ b/Proyecto-Final/AGENTS.md
@@ -236,7 +236,7 @@ Los **10 TCs PF-native** sobre HU-01 Radicar PQRS están abiertos como issues #3
 
 ### 10.7 Kanban Fase 2
 
-**Board**: https://github.com/users/13rianVargas/projects/2 (PQRS Fase 2 — MVP Implementation).
+**Board**: https://github.com/users/13rianVargas/projects/2 (PQRS Backlog) — público, linkeado al repo.
 
 **Labels por área**: `phase-2` + uno de `backend`, `frontend-web`, `frontend-mobile`, `database`, `cicd`.
 

--- a/Proyecto-Final/docs/DEPLOY.md
+++ b/Proyecto-Final/docs/DEPLOY.md
@@ -1,0 +1,54 @@
+# Deploy Backend en Render
+
+## Setup inicial (Juli C, una sola vez)
+
+1. Crear cuenta en https://render.com (gratis).
+2. Dashboard → New → Web Service → Connect GitHub repo `Ingenieria-de-Software-1`.
+3. Configuración:
+   - Branch: `develop`
+   - Root directory: `Proyecto-Final/backend/pqrs`
+   - Runtime: Docker
+   - Plan: Free
+   - Auto-deploy: Yes
+4. Environment variables (desde Render dashboard):
+   - `DATABASE_URL` (pooled, Neon)
+   - `JWT_SECRET` (generate value)
+   - `RESEND_API_KEY`
+   - `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_ENDPOINT`, `R2_BUCKET`
+5. Health check path: `/actuator/health`.
+6. Deploy → esperar 5-10 min.
+
+## URL pública
+
+Render genera URL tipo `https://pqrs-backend-XXXX.onrender.com`. Compartir con Santi + Juli A por WhatsApp privado.
+
+## Auto-deploy
+
+Cada push a `develop` que toque `Proyecto-Final/backend/pqrs/**` dispara redeploy automático. Sin GitHub Action adicional.
+
+## Sleep mode (free tier)
+
+Después de 15 min sin tráfico, instancia hiberna. Primer request tarda ~50 s en despertar.
+
+**Pre-warm pre-demo**: 5 min antes ejecutar:
+
+```bash
+curl https://pqrs-backend-XXXX.onrender.com/actuator/health
+```
+
+Para la feria (2-jun), correr en loop cada 4 min las 2 h previas:
+
+```bash
+while true; do curl -s https://pqrs-backend-XXXX.onrender.com/actuator/health > /dev/null; sleep 240; done
+```
+
+## Logs
+
+Render dashboard → Service → Logs (live tail).
+
+## Plan B si Render cae el día de la demo
+
+1. Juli C arranca backend local: `./mvnw spring-boot:run` en `Proyecto-Final/backend/pqrs`.
+2. Habilitar hotspot WiFi en su laptop.
+3. APK móvil + frontend web apuntan a `http://<IP-LAN>:8080`.
+4. Verificar `application.yml` permite CORS desde IP LAN.


### PR DESCRIPTION
## Summary
Phase 2 CI/CD groundwork from PLAN-CICD §T-5.3, T-5.5, T-5.6, T-5.7.

- T-5.7 dependabot config (maven, npm, github-actions, gradle)
- T-5.5 issue templates: feature-request + user-story
- T-5.6 PR template extended with Phase 2 checklist
- T-5.3 DEPLOY.md (Render auto-deploy + pre-warm strategy + plan B)

Closes #88
Closes #90
Closes #91
Closes #92

## Blocked (out of scope of this PR)
- T-5.1 backend-ci real → blocked by PLAN-BACK T-2.1 (no real pom yet) — issue #86
- T-5.2 mobile-ci → blocked by PLAN-MOBILE T-4.1 (no Capacitor yet) — issue #87
- T-5.4 GitHub Project Kanban → executed via gh CLI separately (no code commit) — issue #89

## Test plan
- [ ] CI green (commitlint passes)
- [ ] Dependabot picks up config on next scan
- [ ] New issue templates appear in "New Issue" picker
- [ ] PR template renders Phase 2 section