### PR TITLE
fix: strip surrounding quotes from database url for render deploy

### DIFF
--- a/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/infrastructure/persistencia/DataSourceConfig.java
+++ b/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/infrastructure/persistencia/DataSourceConfig.java
@@ -21,7 +21,7 @@ public class DataSourceConfig {
 
     @Bean
     public DataSource dataSource(@Value("${DATABASE_URL}") String rawUrl) throws URISyntaxException {
-        URI uri = new URI(rawUrl);
+        URI uri = new URI(limpiar(rawUrl));
 
         String userInfo = uri.getUserInfo();
         if (userInfo == null || !userInfo.contains(":")) {
@@ -58,5 +58,23 @@ public class DataSourceConfig {
         ds.setMaximumPoolSize(10);
         ds.setMinimumIdle(2);
         return ds;
+    }
+
+    /**
+     * Tolera valores con espacios o comillas envolventes. Render pasa el valor literal,
+     * asi que si en el dashboard se pego con comillas (DATABASE_URL="postgresql://...")
+     * el URI fallaria con "Illegal character in scheme name at index 0".
+     */
+    private String limpiar(String valor) {
+        if (valor == null) {
+            throw new IllegalStateException("DATABASE_URL no definida");
+        }
+        String v = valor.trim();
+        if (v.length() >= 2
+                && ((v.startsWith("\"") && v.endsWith("\""))
+                || (v.startsWith("'") && v.endsWith("'")))) {
+            v = v.substring(1, v.length() - 1).trim();
+        }
+        return v;
     }
 }


### PR DESCRIPTION
## Problema
Deploy en Render fallaba al arrancar:
`Illegal character in scheme name at index 0: "postgresql://..."`

Causa: Render pasa el valor de la env var literal. Si `DATABASE_URL` se pega con comillas en el dashboard, el valor empieza en `"` y `new URI(rawUrl)` falla. En local no pasa porque `source .env` en bash quita las comillas; Render no.

## Fix
`DataSourceConfig.limpiar()` hace trim + quita comillas envolventes (`"` o `'`) antes de parsear el URI. Tolera ambos casos (con o sin comillas).

## Verificado
Boot local OK con `DATABASE_URL` envuelto en comillas literales → `/actuator/health` 200.

## Test plan
- [ ] CI verde
- [ ] Redeploy Render arranca sin error de scheme