### PR TITLE
fix: disable mail health indicator that blocks actuator health

### DIFF
--- a/Proyecto-Final/backend/pqrs/src/main/resources/application.yml
+++ b/Proyecto-Final/backend/pqrs/src/main/resources/application.yml
@@ -55,6 +55,13 @@ r2:
   bucket: ${R2_BUCKET:pqrs-anexos}
   public-base: ${R2_PUBLIC_BASE:}
 
+management:
+  health:
+    mail:
+      # Deshabilitado: MailHealthIndicator abre conexion SMTP en cada /actuator/health
+      # (Gmail tarda >2min) -> el health check de Render se cuelga y el deploy falla.
+      enabled: false
+
 logging:
   level:
     co.edu.konrad: INFO


### PR DESCRIPTION
## Problema
Tras agregar spring-boot-starter-mail, `MailHealthIndicator` abre conexion SMTP a Gmail en cada `GET /actuator/health`. Gmail tarda >2min (WARN: "took 133531ms to respond") -> el health check de Render se cuelga -> deploy queda update_in_progress / falla.

## Fix
`management.health.mail.enabled=false` en application.yml. (En prod ya aplicado via env var MANAGEMENT_HEALTH_MAIL_ENABLED=false para unblock inmediato.)

## Test plan
- [ ] /actuator/health responde rapido (<1s)
- [ ] deploy Render llega a live