### PR TITLE
feat: add pqrs detail endpoint with tramite timeline

### DIFF
--- a/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/api/rest/PqrsController.java
+++ b/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/api/rest/PqrsController.java
@@ -8,6 +8,7 @@ import co.edu.konrad.pqrs.domain.model.Usuario;
 import co.edu.konrad.pqrs.domain.port.AdjuntoRepositorio;
 import co.edu.konrad.pqrs.domain.port.AlmacenAdjuntos;
 import co.edu.konrad.pqrs.domain.port.PqrsRepositorio;
+import co.edu.konrad.pqrs.domain.port.TramiteRepositorio;
 import co.edu.konrad.pqrs.domain.port.UsuarioRepositorio;
 import co.edu.konrad.pqrs.domain.service.ServicioRadicarPqrs;
 import co.edu.konrad.pqrs.domain.service.ServicioTramitar;
@@ -39,6 +40,7 @@ public class PqrsController {
     private final GeneradorReportePdf generadorReportePdf;
     private final AdjuntoRepositorio adjuntoRepositorio;
     private final AlmacenAdjuntos almacenAdjuntos;
+    private final TramiteRepositorio tramiteRepositorio;
 
     public PqrsController(ServicioRadicarPqrs servicioRadicar,
                           ServicioTramitar servicioTramitar,
@@ -46,7 +48,8 @@ public class PqrsController {
                           PqrsRepositorio pqrsRepositorio,
                           GeneradorReportePdf generadorReportePdf,
                           AdjuntoRepositorio adjuntoRepositorio,
-                          AlmacenAdjuntos almacenAdjuntos) {
+                          AlmacenAdjuntos almacenAdjuntos,
+                          TramiteRepositorio tramiteRepositorio) {
         this.servicioRadicar = servicioRadicar;
         this.servicioTramitar = servicioTramitar;
         this.usuarioRepositorio = usuarioRepositorio;
@@ -54,6 +57,19 @@ public class PqrsController {
         this.generadorReportePdf = generadorReportePdf;
         this.adjuntoRepositorio = adjuntoRepositorio;
         this.almacenAdjuntos = almacenAdjuntos;
+        this.tramiteRepositorio = tramiteRepositorio;
+    }
+
+    /** Detalle de una PQRS: cabecera + timeline de tramites + adjuntos. */
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAnyRole('gestor','admin','cliente')")
+    public ResponseEntity<PqrsDetalleResponse> detalle(@PathVariable("id") Integer id) {
+        Pqrs pqrs = pqrsRepositorio.buscarPorId(id)
+                .orElseThrow(() -> new PqrsNoEncontradaException("PQRS no encontrada: " + id));
+        return ResponseEntity.ok(PqrsDetalleResponse.desde(
+                pqrs,
+                tramiteRepositorio.buscarPorPqrs(id),
+                adjuntoRepositorio.buscarPorPqrs(id)));
     }
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/api/rest/PqrsDetalleResponse.java
+++ b/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/api/rest/PqrsDetalleResponse.java
@@ -1,0 +1,61 @@
+package co.edu.konrad.pqrs.api.rest;
+
+import co.edu.konrad.pqrs.domain.model.Adjunto;
+import co.edu.konrad.pqrs.domain.model.EstadoPqrs;
+import co.edu.konrad.pqrs.domain.model.Pqrs;
+import co.edu.konrad.pqrs.domain.model.TipoPqrs;
+import co.edu.konrad.pqrs.domain.model.Tramite;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/** Detalle completo de una PQRS: cabecera + timeline de tramites + adjuntos. */
+public record PqrsDetalleResponse(
+        Integer id,
+        String radicado,
+        TipoPqrs tipo,
+        String asunto,
+        String descripcion,
+        EstadoPqrs estado,
+        Integer clienteId,
+        Integer gestorId,
+        LocalDateTime fechaRadicado,
+        LocalDateTime fechaCierre,
+        List<TramiteItem> tramites,
+        List<AdjuntoItem> adjuntos
+) {
+    public record TramiteItem(
+            EstadoPqrs estadoAnterior,
+            EstadoPqrs estadoNuevo,
+            String justificacion,
+            Integer gestorId,
+            LocalDateTime timestamp
+    ) {
+        static TramiteItem desde(Tramite t) {
+            return new TramiteItem(t.getEstadoAnterior(), t.getEstadoNuevo(),
+                    t.getJustificacion(), t.getGestorId(), t.getTimestamp());
+        }
+    }
+
+    public record AdjuntoItem(
+            Integer id,
+            String nombreArchivo,
+            String tipoMime,
+            long tamanoBytes,
+            LocalDateTime fechaSubida
+    ) {
+        static AdjuntoItem desde(Adjunto a) {
+            return new AdjuntoItem(a.getId(), a.getNombreArchivo(), a.getTipoMime(),
+                    a.getTamanoBytes(), a.getFechaSubida());
+        }
+    }
+
+    public static PqrsDetalleResponse desde(Pqrs p, List<Tramite> tramites, List<Adjunto> adjuntos) {
+        return new PqrsDetalleResponse(
+                p.getId(), p.getRadicado(), p.getTipo(), p.getAsunto(), p.getDescripcion(),
+                p.getEstado(), p.getClienteId(), p.getGestorId(),
+                p.getFechaRadicado(), p.getFechaCierre(),
+                tramites.stream().map(TramiteItem::desde).toList(),
+                adjuntos.stream().map(AdjuntoItem::desde).toList());
+    }
+}


### PR DESCRIPTION
## Summary
`GET /api/pqrs/{id}` — detalle completo de una PQRS para vistas de detalle (mobile T-4.7, web tramite page).

Retorna:
- Cabecera PQRS (radicado, tipo, asunto, descripcion, estado, fechas, cliente/gestor)
- **timeline de tramites** (estado anterior/nuevo, justificacion, gestor, timestamp)
- adjuntos (metadata: nombre, mime, tamano, fecha)

Roles: gestor/admin/cliente. 404 si no existe.

## Tests
- 35 tests verdes, JaCoCo 76% (>=70% DoD).
- Endpoint es delegacion (repos ya testeados); DTO excluido de coverage (boilerplate).

## Cambios
- PqrsDetalleResponse (record + TramiteItem/AdjuntoItem anidados)
- PqrsController: GET /{id} + inyecta TramiteRepositorio

## Test plan
- [ ] CI verde
- [ ] GET /api/pqrs/{id} retorna timeline