### PR TITLE
docs: rescope plan-mobile to web localhost (drop apk)

### DIFF
--- a/Proyecto-Final/PLAN-MOBILE.md
+++ b/Proyecto-Final/PLAN-MOBILE.md
@@ -1,18 +1,26 @@
 # PLAN-MOBILE — Frontend Mobile Cliente (Fase 2)
 
+> **CAMBIO DE ALCANCE (28-may)**: NO se genera APK. El frontend "mobile" se entrega
+> como **web servida en localhost** (`ionic serve` / `ng serve`) consumiendo el backend
+> en Render. Se elimina Capacitor, Android Studio y GitHub Release del alcance. La demo
+> del rol Cliente se hace en el navegador (puede ser un navegador móvil apuntando al
+> localhost del laptop en la misma red, o el navegador del laptop en modo responsive).
+
 ## 0. Contexto rápido
 
 - **Owner**: Juli Avila (`@JulianAvila259`).
 - **Branch**: `feature/frontend-mobile-core` (crear desde `develop`).
 - **Path**: `Proyecto-Final/frontend/pqrs-app/src/app/mobile/`.
+- **Backend**: `https://ingenieria-de-software-1-uxxj.onrender.com` (LIVE, verificado).
 - **Estado actual** (~60 %):
   - `login/` 100 % funcional.
   - `radicar/` 100 % funcional (formulario + adjuntar PDF + validaciones).
   - `historial/` 20 % — routing + skeleton, sin UI.
   - `detalle/` 0 % — routing solo.
-  - **Capacitor NO instalado**. Sin `android/` ni `ios/` folders. Sin `capacitor.config.ts`. Sin paquetes en `package.json`.
-- **Definición Done**: APK Android sideload-able instalado en 2-3 celulares del equipo, login → radicar PQRS (con PDF en R2) → historial → detalle funciona end-to-end contra backend Render.
-- **Bloqueado por**: PLAN-BACK.md T-2.4 (radicar) y T-2.5 (mis PQRS) para validar integración.
+  - **NO se usa Capacitor**. Es una app Ionic/Angular que corre como web.
+- **Definición Done**: login → radicar PQRS (con PDF a R2 vía backend) → historial → detalle
+  funciona end-to-end **en el navegador contra Render**.
+- **Bloqueado por**: nada. Backend ya expone todos los endpoints (ver §1.1).
 
 ---
 
@@ -22,11 +30,8 @@
 |---|---|---|
 | Node.js | ≥ 20 LTS | `node -v` |
 | pnpm | ≥ 9 | `pnpm -v` |
-| **Android Studio** | Hedgehog (2023.1.1) o superior | https://developer.android.com/studio |
-| Android SDK Platform 33+ (API 33) | bundled con AS | desde AS → SDK Manager |
-| JDK | 17 (mismo que backend) | `java -version` (AS embebe 17) |
-| Cel Android con USB debugging | API 28+ | Settings → About Phone → tap 7x "Build number" → habilitar Dev Options + USB Debugging |
-| URL backend Render | (de Juli C) | `curl https://pqrs-backend-xxx.onrender.com/actuator/health` |
+| Navegador moderno | Chrome/Edge/Firefox | — |
+| URL backend Render | (fija) | `curl https://ingenieria-de-software-1-uxxj.onrender.com/actuator/health` → `{"status":"UP"}` |
 
 **Setup inicial**:
 
@@ -35,237 +40,158 @@ cd Proyecto-Final/frontend/pqrs-app
 pnpm install
 ```
 
+> **Nota cold start**: el backend free en Render hiberna tras 15 min sin tráfico. El primer
+> request puede tardar ~50 s. Pre-warma con el `curl` de health antes de probar.
+
+### 1.1 Contrato de endpoints backend (YA disponibles)
+
+Base: `https://ingenieria-de-software-1-uxxj.onrender.com`. Todos menos login requieren
+header `Authorization: Bearer <token>`.
+
+| Método | Ruta | Uso | Respuesta |
+|---|---|---|---|
+| POST | `/api/auth/login` | login | `{ token, rol, expiraEn }` |
+| POST | `/api/pqrs` | radicar (multipart) | `201 { radicado, fechaRadicado, estado }` |
+| GET | `/api/pqrs/mis?radicado=<opt>` | mis PQRS (Cliente) | **array** de `{ id, radicado, tipo, asunto, estado, fechaRadicado, fechaCierre }` |
+| GET | `/api/pqrs/{id}` | detalle + timeline | `{ id, radicado, tipo, asunto, descripcion, estado, clienteId, gestorId, fechaRadicado, fechaCierre, tramites:[{estadoAnterior, estadoNuevo, justificacion, gestorId, timestamp}], adjuntos:[{id, nombreArchivo, tipoMime, tamanoBytes, fechaSubida}] }` |
+| GET | `/api/pqrs/{id}/anexo` | descargar PDF | `application/pdf` (bytes) |
+
+> **OJO**: `/api/pqrs/mis` devuelve un **array plano, sin paginación**. No esperar
+> `{items, page, size}`. Filtrar por `radicado` se hace con el query param o en cliente.
+
+Usuario demo Cliente: `cliente@demo.com` / `Demo2026!`.
+
 ---
 
 ## 2. Tareas en orden estricto
 
-### T-4.1 Instalar Capacitor (~1 hr)
+### T-4.1 Environment + base URL (~30 min)
 
-**Objetivo**: agregar Capacitor + plataforma Android al proyecto monorepo.
+**Objetivo**: la app apunta al backend Render. Mismo `apiBaseUrl` que usa web.
 
 **Pasos**:
 
-1. Instalar paquetes Capacitor:
+1. Confirmar `src/environments/environment.ts` y `environment.prod.ts`:
+
+```ts
+export const environment = {
+  production: false,
+  apiBaseUrl: 'https://ingenieria-de-software-1-uxxj.onrender.com/api',
+};
+```
+
+2. Verificar que NINGÚN service mobile hardcodea localhost:
+
+```bash
+grep -rn "localhost" src/app/mobile/
+```
+
+3. CORS: el backend ya permite `http://localhost:4200`, `http://localhost:8100`. Si sirves
+   en otro puerto, avisar a Brian para sumarlo a `SecurityConfig`.
+
+**Commit**: `chore(mobile): point environment to render backend base url`
+
+---
+
+### T-4.2 Servir la app como web (~15 min)
+
+**Objetivo**: levantar la app en el navegador.
+
+**Pasos**:
 
 ```bash
 cd Proyecto-Final/frontend/pqrs-app
-pnpm add @capacitor/core @capacitor/android
-pnpm add -D @capacitor/cli
+pnpm ng serve            # http://localhost:4200
+# o, si usas Ionic CLI:
+# pnpm ionic serve       # http://localhost:8100
 ```
 
-2. Inicializar Capacitor:
+Abrir el navegador en la URL. Para vista "móvil": DevTools → toggle device toolbar
+(responsive) → elegir un teléfono.
 
-```bash
-pnpm exec cap init "PQRS SuperMarket" "co.edu.konrad.pqrs" --web-dir=dist/pqrs-app/browser
-```
-
-Esto crea `capacitor.config.ts`:
-
-```ts
-import type { CapacitorConfig } from '@capacitor/cli';
-
-const config: CapacitorConfig = {
-  appId: 'co.edu.konrad.pqrs',
-  appName: 'PQRS SuperMarket',
-  webDir: 'dist/pqrs-app/browser',
-  server: {
-    androidScheme: 'https',
-    cleartext: false,
-  },
-};
-
-export default config;
-```
-
-3. Sumar plataforma Android:
-
-```bash
-pnpm exec cap add android
-```
-
-Esto crea `Proyecto-Final/frontend/pqrs-app/android/` (Gradle project).
-
-4. Instalar plugins necesarios:
-
-```bash
-pnpm add @capacitor/filesystem @capacitor/preferences @capacitor/status-bar @capacitor/app
-pnpm add @capawesome/capacitor-file-picker
-```
-
-5. Sync:
-
-```bash
-pnpm exec cap sync android
-```
-
-**Verificación**:
-
-```bash
-ls android/app/build.gradle android/gradle.properties
-```
-
-Esperado: ambos archivos existen.
-
-**Commits**:
-1. `feat(mobile): add capacitor core and android platform`
-2. `feat(mobile): add capacitor plugins filesystem preferences status-bar file-picker`
+**Sin commit** (operación local).
 
 ---
 
-### T-4.2 Configurar Android Studio (~1 hr)
+### T-4.3 Validar login contra backend real (~1 hr)
 
-**Objetivo**: poder abrir el proyecto Android desde AS y ver el build OK.
-
-**Pasos**:
-
-1. Instalar Android Studio (si no está). Plataforma Hedgehog mínimo.
-2. Primer arranque: AS pide instalar SDK Platform 33 + SDK Build-Tools 33 + Android Emulator (opcional).
-3. Configurar `local.properties` (auto-generado al abrir proyecto):
-
-```
-sdk.dir=/Users/<usuario>/Library/Android/sdk
-```
-
-4. Abrir proyecto Android desde Capacitor:
-
-```bash
-pnpm exec cap open android
-```
-
-Esto lanza AS con el proyecto en `android/`.
-
-5. Esperar a que Gradle sync termine (puede tomar 5-10 min primera vez).
-
-6. Verificar:
-   - Sin errores rojos en panel "Problems".
-   - Build > Make Project → BUILD SUCCESSFUL.
-
-**Sin commit** (es setup local).
-
----
-
-### T-4.3 Environment + base URL (~30 min)
-
-**Objetivo**: mobile apunta a backend Render. Aplicar mismo refactor que web.
+**Objetivo**: `cliente@demo.com` / `Demo2026!` entra desde el navegador.
 
 **Pasos**:
 
-1. Asegurar que `src/environments/environment.ts` y `environment.prod.ts` tienen `apiBaseUrl` (ya hecho en PLAN-WEB.md T-3.2 si Santi llegó primero).
-
-2. Verificar mobile services usan `environment.apiBaseUrl`:
-
-```bash
-grep -n "localhost" src/app/mobile/**/*.ts
-```
-
-3. CORS: coordinar con Juli C — backend `SecurityConfig` debe incluir `capacitor://localhost` y `https://localhost` en `setAllowedOrigins()` (PLAN-BACK.md T-2.1 paso 2.1.5 ya lo tiene).
-
-4. En `capacitor.config.ts`, sumar `server.allowNavigation`:
-
-```ts
-server: {
-  androidScheme: 'https',
-  cleartext: false,
-  allowNavigation: ['pqrs-backend-<HASH>.onrender.com'],
-},
-```
-
-**Commit**: `chore(mobile): configure capacitor server allowed navigation for render backend`
-
----
-
-### T-4.4 Validar login mobile contra backend real (~1 hr)
-
-**Objetivo**: usuario `cliente@demo.com` / `Demo2026!` puede entrar desde APK.
-
-**Pasos**:
-
-1. Build web bundle:
-   ```bash
-   pnpm ng build --configuration=production
-   ```
-2. Sync:
-   ```bash
-   pnpm exec cap sync android
-   ```
-3. Run en emulador o cel real:
-   ```bash
-   pnpm exec cap run android
-   ```
-   (Requiere cel conectado USB con debug habilitado, o emulator running).
-
-4. App abre → login → ingresar credenciales → debe pedir POST `/api/auth/login` al Render URL.
-
-**Logs**:
-- Chrome DevTools remoto: en navegador desktop, ir a `chrome://inspect`. Seleccionar el dispositivo.
-- Logcat AS: filtrar por tag `Capacitor`.
+1. En la pantalla login, enviar `POST {apiBaseUrl}/auth/login` con `{ email, clave }`.
+2. Guardar el `token` (ej. `localStorage`) y agregarlo como header
+   `Authorization: Bearer <token>` en un HTTP interceptor para el resto de requests.
+3. Tras éxito, navegar a `/mobile/historial`.
 
 **Si falla**:
-- Network error → backend caído o URL mal. Verificar `environment.prod.ts`.
-- CORS → backend no permite `capacitor://localhost`.
-- SSL handshake → `cleartext: false` correcto, pero URL debe ser HTTPS.
+- Network error → backend hibernando (espera ~50 s) o URL mal.
+- CORS → puerto no permitido; avisar a Brian.
+- 401 → credenciales incorrectas (verificar email/clave).
 
-**Commit**: `fix(mobile): polish login error handling for capacitor backend integration`
+**Logs**: DevTools → Network / Console del navegador.
+
+**Commit**: `fix(mobile): wire login to backend and store jwt for interceptor`
 
 ---
 
-### T-4.5 Validar Radicar PQRS con PDF (~2 hrs)
+### T-4.4 Radicar PQRS con PDF (~2 hrs)
 
-**Objetivo**: Cliente en APK radica PQRS con anexo PDF que sube a R2 vía backend.
+**Objetivo**: Cliente radica PQRS con anexo PDF que sube a R2 vía backend.
 
 **Pasos**:
 
-1. Verificar `src/app/mobile/radicar/radicar.page.ts` usa `@capawesome/capacitor-file-picker` para abrir selector PDF:
+1. Selector de archivo nativo del navegador (NO Capacitor):
+
+```html
+<input type="file" accept="application/pdf" (change)="onArchivo($event)" />
+```
 
 ```ts
-import { FilePicker } from '@capawesome/capacitor-file-picker';
-
-async seleccionarPdf() {
-  const result = await FilePicker.pickFiles({ types: ['application/pdf'], multiple: false });
-  if (result.files.length > 0) {
-    this.archivoSeleccionado = result.files[0];
-  }
+onArchivo(ev: Event) {
+  const input = ev.target as HTMLInputElement;
+  this.archivo = input.files?.[0] ?? null;
 }
 ```
 
-2. Enviar al backend con FormData:
+2. Enviar como `multipart/form-data`:
 
 ```ts
 const fd = new FormData();
 fd.append('pqrs', new Blob([JSON.stringify(pqrsData)], { type: 'application/json' }));
-if (this.archivoSeleccionado) {
-  const blob = await fetch(`data:${this.archivoSeleccionado.mimeType};base64,${this.archivoSeleccionado.data}`).then(r => r.blob());
-  fd.append('anexo', blob, this.archivoSeleccionado.name);
+if (this.archivo) {
+  fd.append('anexo', this.archivo, this.archivo.name);
 }
 this.http.post(`${environment.apiBaseUrl}/pqrs`, fd).subscribe(...);
 ```
+
+> No setear `Content-Type` manualmente; el navegador agrega el boundary del multipart.
 
 3. Validaciones cliente:
    - Tipo MIME `application/pdf`.
    - Tamaño ≤ 5 MB.
    - Asunto 5-200 chars.
    - Descripción ≥ 20 chars.
+   - Tipo ∈ `peticion | queja | reclamo | sugerencia`.
 
-4. Tras éxito (HTTP 201): mostrar toast "PQRS radicada: <radicado>" + navegar a `/mobile/historial`.
+4. Tras éxito (HTTP 201): toast "PQRS radicada: <radicado>" + navegar a `/mobile/historial`.
 
-**Tests manuales** (corresponden a TCs PF-native issues #37-#46):
+**Tests manuales** (TCs PF-native issues #37-#46):
 - TC-001 Radicar autenticado happy path.
-- TC-005 Adjuntar JPG → error.
+- TC-005 Adjuntar JPG → error (cliente o backend 422).
 - TC-006 Adjuntar PDF 6 MB → error.
 - TC-007 Radicar sin adjunto → OK.
 
-**Commit**: `feat(mobile): integrate file picker pdf for radicar pqrs flow`
+**Commit**: `feat(mobile): radicar pqrs with html file input and multipart upload`
 
 ---
 
-### T-4.6 Historial CU-04 (~5 hrs)
+### T-4.5 Historial CU-04 (~5 hrs)
 
-**Objetivo**: `/mobile/historial` lista PQRS del Cliente.
+**Objetivo**: `/mobile/historial` lista las PQRS del Cliente.
 
 **Archivos**:
-- `src/app/mobile/historial/historial.page.ts`
-- `src/app/mobile/historial/historial.page.html`
-- `src/app/mobile/historial/historial.page.scss`
+- `src/app/mobile/historial/historial.page.{ts,html,scss}`
 
 **HTML** (Ionic):
 
@@ -294,7 +220,7 @@ this.http.post(`${environment.apiBaseUrl}/pqrs`, fd).subscribe(...);
   </div>
 
   <ion-list>
-    <ion-item *ngFor="let p of radicados" [routerLink]="['/mobile/detalle', p.radicado]" detail>
+    <ion-item *ngFor="let p of radicados" [routerLink]="['/mobile/detalle', p.id]" detail>
       <ion-label>
         <h2>{{ p.radicado }}</h2>
         <p>{{ p.tipo | titlecase }} · {{ p.fechaRadicado | date:'short' }}</p>
@@ -302,57 +228,65 @@ this.http.post(`${environment.apiBaseUrl}/pqrs`, fd).subscribe(...);
       </ion-label>
     </ion-item>
   </ion-list>
-
-  <ion-infinite-scroll (ionInfinite)="cargarMas($event)">
-    <ion-infinite-scroll-content />
-  </ion-infinite-scroll>
 </ion-content>
+```
+
+> **Navegar al detalle por `id`** (no por radicado): el endpoint de detalle es `/api/pqrs/{id}`.
+
+**Servicio** (`pqrs.service.ts`):
+
+```ts
+// /mis devuelve un ARRAY plano (sin paginación)
+misRadicados(radicado?: string): Observable<PqrsResumen[]> {
+  let params = new HttpParams();
+  if (radicado) params = params.set('radicado', radicado);
+  return this.http.get<PqrsResumen[]>(`${environment.apiBaseUrl}/pqrs/mis`, { params });
+}
 ```
 
 **TS**:
 
 ```ts
-ngOnInit() {
-  this.cargar();
-}
+ngOnInit() { this.cargar(); }
 
 cargar() {
   this.loading = true;
-  this.pqrsService.misRadicados({ radicado: this.filtroRadicado, page: 0, size: 20 }).subscribe({
-    next: (data) => { this.radicados = data.items; this.loading = false; },
+  this.pqrsService.misRadicados(this.filtroRadicado).subscribe({
+    next: (data) => { this.radicados = data; this.loading = false; },
     error: () => { this.loading = false; this.toast('Error cargando radicados'); }
   });
 }
 
 recargar(ev: any) { this.cargar(); ev.target.complete(); }
-buscar() { /* debounce 300ms */ }
-cargarMas(ev: any) { /* paginate */ }
-```
-
-**Servicio** (`pqrs.service.ts`):
-
-```ts
-misRadicados(filtros: { radicado?: string; page: number; size: number }): Observable<PagedResponse<PqrsResumen>> {
-  const params = new HttpParams({ fromObject: filtros as any });
-  return this.http.get<PagedResponse<PqrsResumen>>(`${environment.apiBaseUrl}/pqrs/mis`, { params });
-}
+buscar() { /* debounce 300ms y volver a llamar cargar() */ }
 ```
 
 **Tests manuales**:
 - Cliente con 0 PQRS → empty state.
-- Cliente con 1 PQRS → muestra.
+- Cliente con ≥ 1 PQRS → muestra lista.
 - Pull-to-refresh actualiza.
 - Buscar por radicado filtra.
 
-**Commit**: `feat(mobile): add historial page with list filter refresh and infinite scroll`
+**Commit**: `feat(mobile): add historial page with list filter and refresh`
 
 ---
 
-### T-4.7 Detalle PQRS (~4 hrs)
+### T-4.6 Detalle PQRS + timeline (~4 hrs)
 
-**Objetivo**: `/mobile/detalle/:radicado` muestra detalle + timeline + botón descargar anexo.
+**Objetivo**: `/mobile/detalle/:id` muestra detalle + timeline de tramites + botón descargar anexo.
+**Solo lectura** para el Cliente (no cambia estado).
 
-**Similar al T-3.5 del PLAN-WEB.md** pero **solo lectura para Cliente** (no permite cambiar estado).
+**Servicio**:
+
+```ts
+detalle(id: number): Observable<PqrsDetalle> {
+  return this.http.get<PqrsDetalle>(`${environment.apiBaseUrl}/pqrs/${id}`);
+}
+
+descargarAnexo(id: number): Observable<Blob> {
+  return this.http.get(`${environment.apiBaseUrl}/pqrs/${id}/anexo`, { responseType: 'blob' });
+}
+```
 
 **HTML**:
 
@@ -361,16 +295,14 @@ misRadicados(filtros: { radicado?: string; page: number; size: number }): Observ
   <ion-card>
     <ion-card-header>
       <ion-card-title>{{ pqrs?.radicado }}</ion-card-title>
-      <ion-card-subtitle>
-        <app-status-badge [estado]="pqrs?.estado" />
-      </ion-card-subtitle>
+      <ion-card-subtitle><app-status-badge [estado]="pqrs?.estado" /></ion-card-subtitle>
     </ion-card-header>
     <ion-card-content>
       <p><strong>Tipo:</strong> {{ pqrs?.tipo }}</p>
       <p><strong>Fecha:</strong> {{ pqrs?.fechaRadicado | date:'medium' }}</p>
       <p><strong>Asunto:</strong> {{ pqrs?.asunto }}</p>
       <p>{{ pqrs?.descripcion }}</p>
-      <ion-button *ngIf="pqrs?.adjunto" (click)="descargarAnexo()" expand="block">
+      <ion-button *ngIf="pqrs?.adjuntos?.length" (click)="descargar()" expand="block">
         <ion-icon name="download" slot="start" /> Descargar Anexo
       </ion-button>
     </ion-card-content>
@@ -379,8 +311,8 @@ misRadicados(filtros: { radicado?: string; page: number; size: number }): Observ
   <ion-card>
     <ion-card-header><ion-card-title>Historial de Estados</ion-card-title></ion-card-header>
     <ion-card-content>
-      <ion-list *ngIf="tramites.length > 0">
-        <ion-item *ngFor="let t of tramites">
+      <ion-list *ngIf="pqrs?.tramites?.length">
+        <ion-item *ngFor="let t of pqrs.tramites">
           <ion-label>
             <h3>{{ t.estadoAnterior }} → {{ t.estadoNuevo }}</h3>
             <p>{{ t.timestamp | date:'short' }}</p>
@@ -388,129 +320,42 @@ misRadicados(filtros: { radicado?: string; page: number; size: number }): Observ
           </ion-label>
         </ion-item>
       </ion-list>
-      <p *ngIf="tramites.length === 0" class="text-gray-500">Sin movimientos aún.</p>
+      <p *ngIf="!pqrs?.tramites?.length" class="text-gray-500">Sin movimientos aún.</p>
     </ion-card-content>
   </ion-card>
 </ion-content>
 ```
 
-**Descargar anexo en mobile** (Capacitor Filesystem):
+**Descargar anexo en el navegador** (sin Capacitor — anchor + object URL):
 
 ```ts
-import { Filesystem, Directory } from '@capacitor/filesystem';
-
-async descargarAnexo() {
-  const blob = await firstValueFrom(this.pqrsService.descargarAnexo(this.pqrs.id));
-  const reader = new FileReader();
-  reader.onload = async () => {
-    const base64 = (reader.result as string).split(',')[1];
-    await Filesystem.writeFile({
-      path: `${this.pqrs.radicado}-anexo.pdf`,
-      data: base64,
-      directory: Directory.Documents,
-    });
-    this.toast('Anexo descargado en Documents');
-  };
-  reader.readAsDataURL(blob);
+descargar() {
+  this.pqrsService.descargarAnexo(this.pqrs.id).subscribe((blob) => {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${this.pqrs.radicado}-anexo.pdf`;
+    a.click();
+    URL.revokeObjectURL(url);
+  });
 }
 ```
 
-**Commit**: `feat(mobile): add detalle pqrs page with status timeline and pdf download`
+**Tests manuales**:
+- PQRS sin tramites → "Sin movimientos aún".
+- PQRS tramitada por gestor → muestra timeline ordenado.
+- PQRS con adjunto → botón descarga el PDF y se abre/guarda correctamente.
 
----
-
-### T-4.8 Build APK release (~2 hrs)
-
-**Objetivo**: generar `app-debug.apk` o `app-release.apk` instalable.
-
-**Pasos** (APK debug, suficiente para sideload demo):
-
-1. Build web prod:
-
-```bash
-pnpm ng build --configuration=production
-```
-
-2. Sync:
-
-```bash
-pnpm exec cap sync android
-```
-
-3. Build APK desde Android Studio:
-   - Open `android/` en AS.
-   - Menu Build → Build Bundle(s) / APK(s) → **Build APK(s)**.
-   - Esperar BUILD SUCCESSFUL.
-   - APK queda en `android/app/build/outputs/apk/debug/app-debug.apk` (~ 15-25 MB).
-
-4. Alternativa CLI:
-
-```bash
-cd android && ./gradlew assembleDebug
-```
-
-5. Verificar firma debug:
-
-```bash
-keytool -printcert -jarfile app/build/outputs/apk/debug/app-debug.apk
-```
-
-**Para APK release firmada** (opcional, no requerida demo):
-
-1. Generar keystore:
-```bash
-keytool -genkey -v -keystore release.keystore -alias pqrs -keyalg RSA -keysize 2048 -validity 10000
-```
-2. Configurar `signingConfig` en `android/app/build.gradle`.
-3. `./gradlew assembleRelease`.
-
-**Sin commit del APK** (gitignored). Sí commitear cambios de Gradle/Capacitor config si los hubo.
-
----
-
-### T-4.9 Publicar APK en GitHub Release (~30 min)
-
-**Objetivo**: APK distribuible vía URL pública.
-
-**Pasos**:
-
-1. Crear tag:
-```bash
-git tag v0.1.0-mvp
-git push origin v0.1.0-mvp
-```
-
-2. Crear Release con APK:
-
-```bash
-gh release create v0.1.0-mvp \
-  --title "PQRS Mobile MVP v0.1.0" \
-  --notes "Versión MVP para feria académica. APK debug sideload. Requiere Android 9+ (API 28)." \
-  Proyecto-Final/frontend/pqrs-app/android/app/build/outputs/apk/debug/app-debug.apk
-```
-
-3. URL queda como `https://github.com/13rianVargas/Ingenieria-de-Software-1/releases/download/v0.1.0-mvp/app-debug.apk`.
-
-4. Instalar en cels demo:
-   - Abrir URL en Chrome móvil → descargar.
-   - Settings → Security → "Instalar apps desconocidas" → habilitar para Chrome.
-   - Tap APK descargada → Instalar.
-
-**Sin commit** (operación GitHub).
+**Commit**: `feat(mobile): add detalle page with timeline and pdf download`
 
 ---
 
 ## 3. Coordinación
 
-- **Bloqueado por**:
-  - PLAN-BACK.md T-2.2 (login) → T-4.4.
-  - PLAN-BACK.md T-2.4 (radicar + R2) → T-4.5.
-  - PLAN-BACK.md T-2.5 (mis PQRS) → T-4.6.
-  - PLAN-BACK.md T-2.6 + T-2.7 (detalle + tramites) → T-4.7.
-  - PLAN-BACK.md T-2.10 (deploy Render) → T-4.3 environment prod.
+- **Bloqueado por**: nada. Backend LIVE con todos los endpoints (§1.1).
 - **Bloquea a**: nadie (mobile es hoja del grafo).
-
-**Estrategia mientras backend no está**: usar JSON Server o mock service para desbloquear UI dev.
+- **CORS**: si sirves en un puerto distinto a 4200/8100, pedir a Brian sumarlo a
+  `SecurityConfig.corsConfigurationSource()`.
 
 ---
 
@@ -518,31 +363,32 @@ gh release create v0.1.0-mvp \
 
 | Error | Fix |
 |---|---|
-| `cap sync` falla con "Could not find @capacitor/android" | Asegurar `pnpm add @capacitor/android` (no devDep). |
-| `gradle sync failed` | Java version mismatch. AS usa embedded JDK 17. Revisar Settings → Build > Gradle > Gradle JDK = embedded. |
-| `cap run android` no detecta cel | USB debug habilitado. `adb devices` debe listar el cel. Cambiar cable USB (algunos son solo carga). |
-| APK no instala "App not installed" | Versión Android < API 28. O ya hay APK firmada con otra key. Desinstalar versión previa. |
-| Backend CORS bloquea desde APK | `setAllowedOrigins(["capacitor://localhost", "https://localhost", ...])` en SecurityConfig. |
-| File picker no retorna data en Android | Permitir permission `READ_EXTERNAL_STORAGE` en `AndroidManifest.xml`. |
-| Filesystem.writeFile error "permission denied" | Sumar `<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />` (solo si API < 29). |
+| Primer request tarda ~50 s o falla | Backend Render hibernado. Pre-warm con `curl .../actuator/health` y reintentar. |
+| CORS bloquea desde el navegador | Puerto no permitido. Avisar a Brian para sumarlo a `setAllowedOrigins()`. |
+| 401 en todas las llamadas | Falta el header `Authorization: Bearer <token>` (revisar interceptor) o token expirado (re-login). |
+| Multipart no sube el PDF | No setear `Content-Type` a mano; dejar que el navegador ponga el boundary. |
+| 422 al adjuntar | El archivo no es `application/pdf` o supera 5 MB (validación backend). |
+| Descarga abre PDF en blanco | Usar `responseType: 'blob'` en el GET del anexo. |
+| `/mis` no pagina | Correcto: devuelve array plano. No esperar `items/page/size`. |
 
 ---
 
 ## 5. Definition of Done
 
-- [ ] T-4.1 Capacitor + Android platform instalados.
-- [ ] T-4.2 Android Studio configurado, Gradle sync OK.
-- [ ] T-4.3 environment + allowNavigation configurado.
-- [ ] T-4.4 login funciona contra backend Render.
-- [ ] T-4.5 radicar PQRS con PDF funciona (sube a R2 via backend).
-- [ ] T-4.6 historial muestra PQRS del Cliente con filtro + pull-to-refresh.
-- [ ] T-4.7 detalle muestra PQRS + timeline + descargar anexo.
-- [ ] T-4.8 APK debug compilado sin errores.
-- [ ] T-4.9 APK publicado en GitHub Release v0.1.0-mvp.
-- [ ] APK instalado en 2-3 cels del equipo.
-- [ ] TCs PF-native (issues #37-#46) ejecutados sobre APK.
+- [ ] T-4.1 environment apunta a Render.
+- [ ] T-4.2 app levanta en el navegador (`ng serve` / `ionic serve`).
+- [ ] T-4.3 login funciona contra backend Render + token persistido.
+- [ ] T-4.4 radicar PQRS con PDF funciona (sube a R2 vía backend).
+- [ ] T-4.5 historial muestra PQRS del Cliente con filtro + pull-to-refresh.
+- [ ] T-4.6 detalle muestra PQRS + timeline + descarga de anexo.
+- [ ] TCs PF-native (issues #37-#46) ejecutados en el navegador.
 - [ ] PR `feature/frontend-mobile-core` mergeado a `develop`.
+
+> **Fuera de alcance** (eliminado 28-may): Capacitor, Android Studio, build APK,
+> GitHub Release, instalación en celulares. Si en el futuro se retoma el APK, basta con
+> `pnpm add @capacitor/core @capacitor/android` + `cap init/add/sync` sobre esta misma base.
 
 ---
 
-**Cronograma ajustado** (ver `PLAN-MAESTRO.md` §2): T-4.1 + T-4.2 + T-4.3 en D1-D2 (22-23 may); T-4.4 + T-4.5 en D3-D5 (24-26 may); T-4.6 + T-4.7 en D6-D8 (27-29 may); T-4.8 build APK en D9-D10 (30-31 may); **T-4.9 GH Release APK + instalar en cels es D11 obligatorio (1-jun)**; demo D12 (2-jun). Total ~17 hrs en 10 días.
+**Cronograma**: sin dependencia de backend (ya está LIVE). T-4.1 + T-4.2 + T-4.3 en un bloque;
+T-4.4 + T-4.5 + T-4.6 en el siguiente. Demo del rol Cliente en navegador. Total estimado ~12 hrs.


### PR DESCRIPTION
## Summary
No alcanzamos APK. Mobile se entrega como **web en localhost** consumiendo Render.

Cambios en PLAN-MOBILE.md:
- Elimina Capacitor, Android Studio, build APK, GitHub Release (T-4.1/4.2/4.8/4.9 viejos).
- Nuevas tareas: environment Render, `ng serve`/`ionic serve`, login, radicar (file input HTML), historial, detalle+timeline.
- Documenta contrato real de endpoints backend (login, /pqrs, /mis [array], /{id} detalle, /{id}/anexo).
- File picker = `<input type=file>` nativo; descarga = anchor+blob (no Capacitor Filesystem).
- DoD sin APK; demo Cliente en navegador.

Para Juli A (@JulianAvila259).