### PR TITLE
docs: update agents and plans with fase 2 current state

### DIFF
--- a/Proyecto-Final/AGENTS.md
+++ b/Proyecto-Final/AGENTS.md
@@ -249,12 +249,11 @@ Los **10 TCs PF-native** sobre HU-01 Radicar PQRS están abiertos como issues #3
 | Servicio | Uso | Tier | Owner |
 |---|---|---|---|
 | **Neon** | PostgreSQL gestionado | Free (compartido 4 devs) | Brian |
-| **Render / Railway / Fly.io** | Hosting backend Spring Boot | Free | Juli C |
-| **Cloudflare R2** | Bucket S3-compatible para PDFs adjuntos | Free (10 GB) | Juli C + Brian |
-| **Resend** | API HTTP envío correos | Free (100/día) | Juli C |
-| **GitHub Actions** | CI (commitlint, frontend-ci, backend-ci, db-migrate, mobile-ci) | Free (2 000 min/mes) | Brian |
-| **GitHub Releases** | Distribución APK Android | Free | Juli A |
-| **GitHub Projects** | Kanban Fase 2 | Free | Brian |
+| **Render** | Hosting backend Spring Boot — LIVE `ingenieria-de-software-1-uxxj.onrender.com` | Free (hiberna 15min) | Brian |
+| **Cloudflare R2** | Bucket S3 `pqrs-anexos` para PDFs adjuntos | Free (10 GB) | Brian |
+| **Gmail SMTP** | Envío correos (reemplazó Resend — no requiere dominio) | Free (~500/día) | Brian |
+| **GitHub Actions** | CI (commitlint, frontend-ci, backend-ci, db-migrate) | Free (2 000 min/mes) | Brian |
+| **GitHub Projects** | Kanban Fase 2 ("PQRS Backlog") | Free | Brian |
 
 ---
 

--- a/Proyecto-Final/PLAN-BACK.md
+++ b/Proyecto-Final/PLAN-BACK.md
@@ -1,5 +1,14 @@
 # PLAN-BACK — Backend Spring Boot (Fase 2)
 
+> ## ✅ COMPLETADO Y DESPLEGADO (28-may-2026)
+> Implementado por **Brian** (Juli C no disponible). LIVE: `https://ingenieria-de-software-1-uxxj.onrender.com`.
+> CU-01..07 + RF-12. 35 tests, 76% cobertura. Código en `backend/pqrs/`.
+> **Cambios vs plan original**:
+> - **T-2.9 usa Gmail SMTP**, no Resend (Resend exigía dominio verificado; SMTP entrega a cualquiera sin dominio).
+> - **T-2.4** anon path no implementado (solo autenticado); radicación anónima = follow-up.
+> - **+ extras**: `GET /api/pqrs/{id}` (detalle+timeline) y `GET /api/pqrs/{id}/anexo` (descarga PDF), no en plan original pero requeridos por front.
+> - Gotchas + env vars: ver [`backend/AGENTS.md`](./backend/AGENTS.md) §"ESTADO".
+
 ## 0. Contexto rápido
 
 - **Owner**: Juli Criollo (`@julianhomezdev`).

--- a/Proyecto-Final/PLAN-CICD.md
+++ b/Proyecto-Final/PLAN-CICD.md
@@ -533,15 +533,15 @@ Settings → Security & analysis → Dependency alerts: Enable. Code scanning: E
 
 ## 5. Definition of Done
 
-- [ ] T-5.1 backend-ci ejecuta maven verify real con JaCoCo + Testcontainers.
-- [ ] T-5.2 mobile-ci workflow operativo.
-- [ ] T-5.3 `DEPLOY.md` documentado + Render configurado.
-- [ ] T-5.4 GitHub Project Kanban Fase 2 con ~30 issues T-X.Y.
-- [ ] T-5.5 templates feature-request + user-story creados.
-- [ ] T-5.6 PR template actualizado con checklist Fase 2.
-- [ ] T-5.7 Dependabot config + alerts habilitados.
-- [ ] Branch protection actualizada con nuevos check names si aplica.
-- [ ] PR `feature/cicd-improvements` mergeado a `develop`.
+- [x] T-5.1 backend-ci ejecuta `mvnw verify -Pcoverage` (JaCoCo). Sin Testcontainers (tests unit, sin Docker). PR #100.
+- [~] T-5.2 mobile-ci **CANCELADO**: mobile se entrega como web; `frontend-ci` (lint+test+ng build) ya cubre el bundle Angular. Issue #87 cerrado not-planned.
+- [x] T-5.3 `DEPLOY.md` documentado + Render configurado + LIVE.
+- [x] T-5.4 GitHub Project Kanban Fase 2 ("PQRS Backlog", público) con 40 issues.
+- [x] T-5.5 templates feature-request + user-story creados.
+- [x] T-5.6 PR template actualizado con checklist Fase 2.
+- [x] T-5.7 Dependabot config.
+- [ ] Branch protection: sumar `maven verify` (backend-ci) como required check si se desea.
+- [x] PRs CICD mergeados a `develop`.
 
 ---
 

--- a/Proyecto-Final/PLAN-MAESTRO.md
+++ b/Proyecto-Final/PLAN-MAESTRO.md
@@ -22,11 +22,11 @@ Sin estos 3 documentos leídos, **no toques código**.
 
 | Plan | Owner | Estado | Branch | Descripción corta |
 |---|---|---|---|---|
-| [`PLAN-DB.md`](./PLAN-DB.md) | Brian | 🟢 Listo para ejecutar | `feature/database-seeds` | Cargar seeds, V6 si aplica, health checks. |
-| [`PLAN-BACK.md`](./PLAN-BACK.md) | Juli Criollo | 🔴 Bloquea web/mobile | `feature/backend-core` | Fix scaffold roto + CU-01..07 + RF-12 + deploy. |
-| [`PLAN-WEB.md`](./PLAN-WEB.md) | Santi | 🟡 Avanzado (~70 %) | `feature/frontend-web-core` | Completar tramite + reportes + shared components + build prod. |
-| [`PLAN-MOBILE.md`](./PLAN-MOBILE.md) | Juli Avila | 🟡 Avanzado (~60 %) | `feature/frontend-mobile-core` | Capacitor + historial + detalle + build APK + GH Release. |
-| [`PLAN-CICD.md`](./PLAN-CICD.md) | Brian | 🟢 Listo para ejecutar | `feature/cicd-improvements` | backend-ci real + mobile-ci + deploy + Kanban. |
+| [`PLAN-DB.md`](./PLAN-DB.md) | Brian | ✅ Completado | merged | Seeds + V6 secuencia radicado + health checks. |
+| [`PLAN-BACK.md`](./PLAN-BACK.md) | Brian (impl) | ✅ Completado + LIVE | merged | CU-01..07 + RF-12. Render: `ingenieria-de-software-1-uxxj.onrender.com`. R2 + Gmail SMTP. 76% cobertura. |
+| [`PLAN-WEB.md`](./PLAN-WEB.md) | Santi | 🟡 En progreso | `feature/frontend-web-core` | Completar tramite + reportes + shared + build prod. Backend LIVE disponible. |
+| [`PLAN-MOBILE.md`](./PLAN-MOBILE.md) | Juli Avila | 🟡 En progreso (rescoped) | `feature/frontend-mobile-core` | **Web localhost (sin APK)**. Login + radicar + historial + detalle vs Render. |
+| [`PLAN-CICD.md`](./PLAN-CICD.md) | Brian | ✅ Casi completo | merged | backend-ci activo + Kanban + Dependabot + templates. mobile-ci cancelado (redundante). |
 
 **Convención de estado**: 🔴 bloqueado / bloquea | 🟡 en progreso | 🟢 listo | ✅ completado.
 
@@ -136,11 +136,11 @@ Para cada CU del MVP (CU-01..CU-07):
 
 | Plan | Última actualización | Tareas completadas | Bloqueos actuales |
 |---|---|---|---|
-| PLAN-DB | (pendiente Brian) | 0 / 4 | — |
-| PLAN-BACK | (pendiente Juli C) | 0 / 10 | scaffold roto, sin pom dependencies completas |
-| PLAN-WEB | (pendiente Santi) | 0 / 7 | espera contrato endpoints backend |
-| PLAN-MOBILE | (pendiente Juli A) | 0 / 9 | Capacitor no instalado |
-| PLAN-CICD | (pendiente Brian) | 0 / 7 | backend-ci placeholder hasta que exista código |
+| PLAN-DB | 28-may | 7 / 7 ✅ | — |
+| PLAN-BACK | 28-may | 10 / 10 ✅ + LIVE | — (Brian implementó; Juli C no disponible) |
+| PLAN-WEB | (Santi) | en progreso | ninguno — backend LIVE disponible |
+| PLAN-MOBILE | 28-may (rescoped) | en progreso | ninguno — web localhost vs Render, sin APK |
+| PLAN-CICD | 28-may | 6 / 7 ✅ | mobile-ci cancelado (redundante con frontend-ci) |
 
 ---
 

--- a/Proyecto-Final/backend/AGENTS.md
+++ b/Proyecto-Final/backend/AGENTS.md
@@ -1,8 +1,64 @@
 # AGENTS.md — Backend (PQRS)
 
-Owner: **Juli Criollo** (`@julianhomezdev`).
+Owner: **Juli Criollo** (`@julianhomezdev`). **Implementado por Brian** (28-may, Juli C no disponible).
 
 Aplica a todo lo que viva en `Proyecto-Final/backend/`. Reglas globales en [`../AGENTS.md`](../AGENTS.md).
+
+---
+
+## ⚠️ ESTADO: IMPLEMENTADO Y DESPLEGADO (28-may-2026)
+
+Backend completo y LIVE. Las secciones de "esqueleto/propuesta" más abajo son históricas.
+
+- **URL producción**: `https://ingenieria-de-software-1-uxxj.onrender.com` (Render, free tier — hiberna 15 min idle, cold start ~50 s).
+- **Código real**: `Proyecto-Final/backend/pqrs/` (NO `backend/` directo).
+- **CU implementados**: CU-01..07 + RF-12. 35 tests JUnit, cobertura JaCoCo ~76%.
+- **Storage adjuntos**: Cloudflare R2 (S3) — funciona. Sin R2 degrada a marcador `pending-r2://` sin romper radicado.
+- **Correos**: **Gmail SMTP** (NO Resend — requería dominio). Worker async cada 30s procesa cola `notificacion`. Entrega a cualquier destinatario.
+
+### Endpoints REALES
+
+| Método | Ruta | Auth |
+|---|---|---|
+| POST | `/api/auth/login` → `{token, rol, expiraEn}` | público |
+| POST | `/api/pqrs` (multipart: `pqrs` JSON + `anexo` PDF opcional) | cliente |
+| GET | `/api/pqrs/mis?radicado=<opt>` → **array** (sin paginación) | cliente |
+| GET | `/api/pqrs` (bandeja, `?estado&tipo&page&size`) → `{contenido,total,page,size}` | gestor/admin |
+| GET | `/api/pqrs/{id}` → detalle + `tramites[]` + `adjuntos[]` | gestor/admin/cliente |
+| GET | `/api/pqrs/{id}/anexo` → PDF bytes | gestor/admin/cliente |
+| PUT | `/api/pqrs/{id}/estado` (`{estado, justificacion}`) | gestor/admin |
+| GET | `/api/pqrs/reporte?estado&tipo` → PDF | gestor/admin |
+| GET | `/swagger-ui.html`, `/v3/api-docs`, `/actuator/health` | público |
+
+Demo users (pass `Demo2026!`): `cliente@demo.com`, `gestor@demo.com`, `brian@demo.com` (admin).
+
+### Variables de entorno (Render dashboard)
+
+| Var | Uso |
+|---|---|
+| `DATABASE_URL` | Neon pooled, formato bare `postgresql://user:pass@host/db?...` (DataSourceConfig lo parsea a JDBC) |
+| `JWT_SECRET` | firma HS256 (≥32 chars) |
+| `MAIL_USERNAME` / `MAIL_PASSWORD` | Gmail + App Password (vacío = worker correos off) |
+| `MAIL_FROM_NOMBRE` | nombre remitente |
+| `R2_ENABLED` `R2_ENDPOINT` `R2_ACCESS_KEY_ID` `R2_SECRET_ACCESS_KEY` `R2_BUCKET` | Cloudflare R2 (vacío/false = LocalAlmacen marcador) |
+| `MANAGEMENT_HEALTH_MAIL_ENABLED=false` | OBLIGATORIA: MailHealthIndicator cuelga `/actuator/health` (>2min) y tumba el deploy |
+
+### Correr local
+
+```bash
+cd Proyecto-Final/backend/pqrs
+set -a && source ../.env && set +a   # .env con DATABASE_URL (+ MAIL_*/R2_* opcional)
+./mvnw spring-boot:run               # :8080
+./mvnw verify -Pcoverage             # tests + JaCoCo (target/site/jacoco/)
+```
+
+### Gotchas (resueltos — no re-romper)
+
+1. **JDK 25**: Lombok ≥1.18.42 obligatorio (1.18.32 → `TypeTag UNKNOWN`). Mockito de clases concretas → surefire `net.bytebuddy.experimental=true`.
+2. **DATABASE_URL bare**: `DataSourceConfig.java` parsea URI → JDBC + filtra `options=search_path` (Neon pooler lo rechaza). search_path pin a nivel rol.
+3. **ddl-auto=none** (+ `hibernate.hbm2ddl.auto=none`): Flyway es source of truth. `validate` falla con SERIAL (Hibernate 6 espera bigint). IDs de entidades = `Integer` (schema es SERIAL).
+4. **devtools removido**: interfería con DataSource bean custom.
+5. **Render healthCheckPath** debe ser `/actuator/health` (no `/actuator/`).
 
 ---
 

--- a/Proyecto-Final/database/README.md
+++ b/Proyecto-Final/database/README.md
@@ -141,7 +141,8 @@ database/
 │   ├── V2__pqrs.sql
 │   ├── V3__tramites_adjuntos.sql
 │   ├── V4__notificaciones.sql
-│   └── V5__auditoria.sql
+│   ├── V5__auditoria.sql
+│   └── V6__pqrs_radicado_sequence.sql   # secuencia consecutivo radicado (backend)
 ├── seeds/                    # datos demo dev only (manual, no via Flyway)
 │   └── demo.sql
 ├── schema/                   # referencia humana (no ejecutable)


### PR DESCRIPTION
## Summary
Sincroniza docs con el estado real tras implementar backend + cambios de alcance.

- **backend/AGENTS.md**: sección "ESTADO: IMPLEMENTADO Y DESPLEGADO" — URL Render, endpoints reales, env vars, gotchas (JDK25/datasource/ddl/mail-health), correr local, tests.
- **PLAN-MAESTRO.md**: §1 tabla de planes + §7 dashboard actualizados (backend ✅ LIVE, db ✅, cicd casi, mobile rescoped).
- **PLAN-BACK.md**: banner ✅ COMPLETADO + cambios vs original (Gmail SMTP no Resend, sin anon path, +endpoints detalle/anexo).
- **PLAN-CICD.md**: DoD — T-5.1 ✅, T-5.2 cancelado, resto ✅.
- **AGENTS.md** (raíz Proyecto-Final): §11 plataformas — Render LIVE, R2, Gmail SMTP (reemplaza Resend), quita APK/Releases.
- **database/README.md**: V6 secuencia radicado.