### PR TITLE
fix: send lowercase pqrs tipo matching backend enum in mobile radicar

### DIFF
--- a/Proyecto-Final/frontend/pqrs-app/src/app/mobile/radicar/radicar.page.html
+++ b/Proyecto-Final/frontend/pqrs-app/src/app/mobile/radicar/radicar.page.html
@@ -16,10 +16,10 @@
     
     <ion-item class="mb-4 rounded-lg border">
       <ion-select formControlName="tipo" label="Tipo de Radicado" label-placement="floating">
-        <ion-select-option value="PETICION">Petición</ion-select-option>
-        <ion-select-option value="QUEJA">Queja</ion-select-option>
-        <ion-select-option value="RECLAMO">Reclamo</ion-select-option>
-        <ion-select-option value="SUGERENCIA">Sugerencia</ion-select-option>
+        <ion-select-option value="peticion">Petición</ion-select-option>
+        <ion-select-option value="queja">Queja</ion-select-option>
+        <ion-select-option value="reclamo">Reclamo</ion-select-option>
+        <ion-select-option value="sugerencia">Sugerencia</ion-select-option>
       </ion-select>
     </ion-item>
     <div *ngIf="radicacionForm.get('tipo')?.invalid && radicacionForm.get('tipo')?.touched" class="text-red-600 text-sm mb-4 px-2">


### PR DESCRIPTION
## Problema
Radicar PQRS mobile fallaba con "Error al radicar PQRS". El `<ion-select>` enviaba `tipo` en MAYÚSCULA (`PETICION`, `QUEJA`...) pero el backend espera el enum `TipoPqrs` en minúscula (`peticion`, `queja`, `reclamo`, `sugerencia`) → 400 `Cannot deserialize value of type TipoPqrs`.

## Fix
`radicar.page.html`: valores del select a minúscula.

## Verificado
Radicar como `cliente@demo.com` en localhost:4200/mobile/radicar → 201, redirige a historial.

## Nota (follow-up)
Mismo mismatch existe en web tramitar (`EstadoPqrs from "RESUELTO"` en logs). Fix global posible: backend `ACCEPT_CASE_INSENSITIVE_ENUMS=true` (1 línea), evitaría todos estos casos. Pendiente decisión.

## Dependencia
Basado sobre #106 (login fix); incluye su commit hasta que #106 mergee. Tras merge de #106, este diff queda limpio (solo radicar).