### PR TITLE
feat: anonymous pqrs radication with auto-registration

### DIFF
--- a/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/api/rest/PqrsController.java
+++ b/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/api/rest/PqrsController.java
@@ -10,6 +10,7 @@ import co.edu.konrad.pqrs.domain.port.AlmacenAdjuntos;
 import co.edu.konrad.pqrs.domain.port.PqrsRepositorio;
 import co.edu.konrad.pqrs.domain.port.TramiteRepositorio;
 import co.edu.konrad.pqrs.domain.port.UsuarioRepositorio;
+import co.edu.konrad.pqrs.domain.service.ServicioRadicarAnonimo;
 import co.edu.konrad.pqrs.domain.service.ServicioRadicarPqrs;
 import co.edu.konrad.pqrs.domain.service.ServicioTramitar;
 import co.edu.konrad.pqrs.domain.service.ServicioTramitar.PqrsNoEncontradaException;
@@ -34,6 +35,7 @@ import java.util.List;
 public class PqrsController {
 
     private final ServicioRadicarPqrs servicioRadicar;
+    private final ServicioRadicarAnonimo servicioRadicarAnonimo;
     private final ServicioTramitar servicioTramitar;
     private final UsuarioRepositorio usuarioRepositorio;
     private final PqrsRepositorio pqrsRepositorio;
@@ -43,6 +45,7 @@ public class PqrsController {
     private final TramiteRepositorio tramiteRepositorio;
 
     public PqrsController(ServicioRadicarPqrs servicioRadicar,
+                          ServicioRadicarAnonimo servicioRadicarAnonimo,
                           ServicioTramitar servicioTramitar,
                           UsuarioRepositorio usuarioRepositorio,
                           PqrsRepositorio pqrsRepositorio,
@@ -51,6 +54,7 @@ public class PqrsController {
                           AlmacenAdjuntos almacenAdjuntos,
                           TramiteRepositorio tramiteRepositorio) {
         this.servicioRadicar = servicioRadicar;
+        this.servicioRadicarAnonimo = servicioRadicarAnonimo;
         this.servicioTramitar = servicioTramitar;
         this.usuarioRepositorio = usuarioRepositorio;
         this.pqrsRepositorio = pqrsRepositorio;
@@ -58,6 +62,19 @@ public class PqrsController {
         this.adjuntoRepositorio = adjuntoRepositorio;
         this.almacenAdjuntos = almacenAdjuntos;
         this.tramiteRepositorio = tramiteRepositorio;
+    }
+
+    /** CU-03 anonimo + CU-01: radicar sin login. Crea cuenta cliente y envia credenciales. */
+    @PostMapping(value = "/anonimo", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<RadicarPqrsResponse> radicarAnonimo(
+            @Valid @RequestPart("pqrs") RadicarAnonimoRequest request,
+            @RequestPart(value = "anexo", required = false) MultipartFile anexo) {
+        ServicioRadicarAnonimo.DatosCliente cliente = new ServicioRadicarAnonimo.DatosCliente(
+                request.tipoDoc(), request.numDoc(), request.nombres(),
+                request.apellidos(), request.email(), request.telefono());
+        Pqrs radicada = servicioRadicarAnonimo.radicar(
+                cliente, request.tipo(), request.asunto(), request.descripcion(), aAnexo(anexo));
+        return ResponseEntity.status(HttpStatus.CREATED).body(RadicarPqrsResponse.desde(radicada));
     }
 
     /** Detalle de una PQRS: cabecera + timeline de tramites + adjuntos. */

--- a/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/api/rest/RadicarAnonimoRequest.java
+++ b/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/api/rest/RadicarAnonimoRequest.java
@@ -1,0 +1,21 @@
+package co.edu.konrad.pqrs.api.rest;
+
+import co.edu.konrad.pqrs.domain.model.TipoDocumento;
+import co.edu.konrad.pqrs.domain.model.TipoPqrs;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record RadicarAnonimoRequest(
+        @NotNull TipoDocumento tipoDoc,
+        @NotBlank String numDoc,
+        @NotBlank String nombres,
+        @NotBlank String apellidos,
+        @Email @NotBlank String email,
+        String telefono,
+        @NotNull TipoPqrs tipo,
+        @NotNull @Size(min = 5, max = 200) String asunto,
+        @NotNull @Size(min = 20) String descripcion
+) {
+}

--- a/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/domain/port/NotificadorCredenciales.java
+++ b/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/domain/port/NotificadorCredenciales.java
@@ -1,0 +1,11 @@
+package co.edu.konrad.pqrs.domain.port;
+
+public interface NotificadorCredenciales {
+
+    /**
+     * Envia (best-effort) las credenciales de acceso a un cliente recien creado
+     * por radicacion anonima. Sincrono porque la clave plana solo existe en este
+     * momento (no se persiste).
+     */
+    void enviarCredenciales(String email, String nombres, String clavePlana, String radicado);
+}

--- a/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/domain/service/ServicioRadicarAnonimo.java
+++ b/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/domain/service/ServicioRadicarAnonimo.java
@@ -1,0 +1,79 @@
+package co.edu.konrad.pqrs.domain.service;
+
+import co.edu.konrad.pqrs.domain.model.Pqrs;
+import co.edu.konrad.pqrs.domain.model.TipoDocumento;
+import co.edu.konrad.pqrs.domain.model.TipoPqrs;
+import co.edu.konrad.pqrs.domain.model.Usuario;
+import co.edu.konrad.pqrs.domain.port.CodificadorClave;
+import co.edu.konrad.pqrs.domain.port.NotificadorCredenciales;
+import co.edu.konrad.pqrs.domain.port.UsuarioRepositorio;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+
+/**
+ * Radicacion anonima (CU-03 + CU-01): un ciudadano sin cuenta radica una PQRS.
+ * Si el email no existe, se crea un usuario cliente con clave temporal y se le
+ * envian las credenciales por correo. Si ya existe, se radica a su nombre.
+ */
+@Service
+public class ServicioRadicarAnonimo {
+
+    private static final String ALFABETO =
+            "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz23456789";
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private final UsuarioRepositorio usuarioRepositorio;
+    private final CodificadorClave codificadorClave;
+    private final NotificadorCredenciales notificadorCredenciales;
+    private final ServicioRadicarPqrs servicioRadicarPqrs;
+
+    public ServicioRadicarAnonimo(UsuarioRepositorio usuarioRepositorio,
+                                  CodificadorClave codificadorClave,
+                                  NotificadorCredenciales notificadorCredenciales,
+                                  ServicioRadicarPqrs servicioRadicarPqrs) {
+        this.usuarioRepositorio = usuarioRepositorio;
+        this.codificadorClave = codificadorClave;
+        this.notificadorCredenciales = notificadorCredenciales;
+        this.servicioRadicarPqrs = servicioRadicarPqrs;
+    }
+
+    public record DatosCliente(TipoDocumento tipoDoc, String numDoc, String nombres,
+                               String apellidos, String email, String telefono) {
+    }
+
+    @Transactional
+    public Pqrs radicar(DatosCliente cliente, TipoPqrs tipo, String asunto, String descripcion,
+                        ServicioRadicarPqrs.Anexo anexo) {
+        Usuario existente = usuarioRepositorio.buscarPorCorreo(cliente.email()).orElse(null);
+
+        Integer clienteId;
+        String clavePlana = null;
+        if (existente != null) {
+            clienteId = existente.getId();
+        } else {
+            clavePlana = generarClave();
+            Usuario nuevo = new Usuario(
+                    cliente.tipoDoc(), cliente.numDoc(), cliente.nombres(), cliente.apellidos(),
+                    cliente.email(), cliente.telefono(), codificadorClave.codificar(clavePlana));
+            clienteId = usuarioRepositorio.guardar(nuevo).getId();
+        }
+
+        Pqrs radicada = servicioRadicarPqrs.radicar(tipo, asunto, descripcion, clienteId, anexo);
+
+        if (clavePlana != null) {
+            notificadorCredenciales.enviarCredenciales(
+                    cliente.email(), cliente.nombres(), clavePlana, radicada.getRadicado());
+        }
+        return radicada;
+    }
+
+    private String generarClave() {
+        StringBuilder sb = new StringBuilder(10);
+        for (int i = 0; i < 10; i++) {
+            sb.append(ALFABETO.charAt(RANDOM.nextInt(ALFABETO.length())));
+        }
+        return sb.toString();
+    }
+}

--- a/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/infrastructure/integraciones/correo/NotificadorCredencialesSmtp.java
+++ b/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/infrastructure/integraciones/correo/NotificadorCredencialesSmtp.java
@@ -1,0 +1,42 @@
+package co.edu.konrad.pqrs.infrastructure.integraciones.correo;
+
+import co.edu.konrad.pqrs.domain.port.NotificadorCredenciales;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Envia las credenciales de acceso por SMTP de forma sincrona y best-effort:
+ * si el correo falla o esta deshabilitado, el radicado sigue siendo valido.
+ */
+@Component
+public class NotificadorCredencialesSmtp implements NotificadorCredenciales {
+
+    private static final Logger log = LoggerFactory.getLogger(NotificadorCredencialesSmtp.class);
+
+    private final CorreoSmtp correo;
+
+    public NotificadorCredencialesSmtp(CorreoSmtp correo) {
+        this.correo = correo;
+    }
+
+    @Override
+    public void enviarCredenciales(String email, String nombres, String clavePlana, String radicado) {
+        if (!correo.habilitado()) {
+            log.warn("SMTP deshabilitado — no se envian credenciales a {} (radicado {})", email, radicado);
+            return;
+        }
+        try {
+            String html = "<p>Hola " + nombres + ",</p>"
+                    + "<p>Tu PQRS fue radicada con el numero <strong>" + radicado + "</strong>.</p>"
+                    + "<p>Creamos una cuenta para que consultes su estado:</p>"
+                    + "<ul><li><strong>Usuario:</strong> " + email + "</li>"
+                    + "<li><strong>Clave temporal:</strong> " + clavePlana + "</li></ul>"
+                    + "<p>Ingresa al portal y cambiala apenas puedas.</p>"
+                    + "<p>SuperMarket Konrad</p>";
+            correo.enviar(email, "Tu PQRS fue radicada — acceso al portal", html);
+        } catch (RuntimeException e) {
+            log.error("Fallo al enviar credenciales a {} (radicado {}): {}", email, radicado, e.getMessage());
+        }
+    }
+}

--- a/Proyecto-Final/backend/pqrs/src/test/java/co/edu/konrad/pqrs/domain/service/ServicioRadicarAnonimoTest.java
+++ b/Proyecto-Final/backend/pqrs/src/test/java/co/edu/konrad/pqrs/domain/service/ServicioRadicarAnonimoTest.java
@@ -1,0 +1,75 @@
+package co.edu.konrad.pqrs.domain.service;
+
+import co.edu.konrad.pqrs.domain.model.Pqrs;
+import co.edu.konrad.pqrs.domain.model.TipoDocumento;
+import co.edu.konrad.pqrs.domain.model.TipoPqrs;
+import co.edu.konrad.pqrs.domain.model.Usuario;
+import co.edu.konrad.pqrs.domain.port.CodificadorClave;
+import co.edu.konrad.pqrs.domain.port.NotificadorCredenciales;
+import co.edu.konrad.pqrs.domain.port.UsuarioRepositorio;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class ServicioRadicarAnonimoTest {
+
+    private UsuarioRepositorio usuarioRepo;
+    private CodificadorClave codificador;
+    private NotificadorCredenciales notifCred;
+    private ServicioRadicarPqrs radicar;
+    private ServicioRadicarAnonimo servicio;
+
+    @BeforeEach
+    void setup() {
+        usuarioRepo = Mockito.mock(UsuarioRepositorio.class);
+        codificador = Mockito.mock(CodificadorClave.class);
+        notifCred = Mockito.mock(NotificadorCredenciales.class);
+        radicar = Mockito.mock(ServicioRadicarPqrs.class);
+        servicio = new ServicioRadicarAnonimo(usuarioRepo, codificador, notifCred, radicar);
+
+        Pqrs result = new Pqrs(TipoPqrs.queja, "Asunto", "desc", 7);
+        result.setRadicado("PQRS-2026-000010");
+        when(radicar.radicar(any(), anyString(), anyString(), anyInt(), any())).thenReturn(result);
+    }
+
+    private ServicioRadicarAnonimo.DatosCliente cliente() {
+        return new ServicioRadicarAnonimo.DatosCliente(
+                TipoDocumento.CC, "123", "Steven", "Clavijo", "steven@demo.com", "300");
+    }
+
+    @Test
+    void clienteNuevoSeRegistraYRecibeCredenciales() {
+        when(usuarioRepo.buscarPorCorreo("steven@demo.com")).thenReturn(Optional.empty());
+        when(codificador.codificar(anyString())).thenReturn("$2a$hash");
+        when(usuarioRepo.guardar(any())).thenAnswer(inv -> {
+            Usuario u = inv.getArgument(0);
+            u.setId(7);
+            return u;
+        });
+
+        Pqrs r = servicio.radicar(cliente(), TipoPqrs.queja, "Asunto valido", "descripcion larga valida aqui", null);
+
+        assertEquals("PQRS-2026-000010", r.getRadicado());
+        verify(usuarioRepo).guardar(any());
+        verify(notifCred).enviarCredenciales(eq("steven@demo.com"), eq("Steven"), anyString(), eq("PQRS-2026-000010"));
+    }
+
+    @Test
+    void clienteExistenteNoSeRegistraNiRecibeCredenciales() {
+        Usuario existente = new Usuario(TipoDocumento.CC, "123", "Steven", "Clavijo",
+                "steven@demo.com", "300", "$2a$hash");
+        existente.setId(7);
+        when(usuarioRepo.buscarPorCorreo("steven@demo.com")).thenReturn(Optional.of(existente));
+
+        servicio.radicar(cliente(), TipoPqrs.peticion, "Asunto valido", "descripcion larga valida aqui", null);
+
+        verify(usuarioRepo, never()).guardar(any());
+        verifyNoInteractions(notifCred);
+    }
+}


### PR DESCRIPTION
## Summary
CU-03 anónimo + CU-01: `POST /api/pqrs/anonimo` (público) permite radicar sin login.

- Si el email no existe → crea usuario cliente con clave temporal aleatoria (10 chars) + envía credenciales por SMTP (sincrónico, best-effort).
- Si el email ya existe → radica a su nombre, sin recrear.
- Reusa `ServicioRadicarPqrs` (validaciones, R2, notificación radicado_creado).
- Hexagonal: `NotificadorCredenciales` port + `NotificadorCredencialesSmtp` adapter.

## Verificado LOCAL (Neon + R2 + SMTP)
`POST /api/pqrs/anonimo` cliente nuevo → 201 `PQRS-2026-000010` + log `Correo SMTP enviado (... acceso al portal)` + usuario creado.

## Tests
2 nuevos (cliente nuevo registra+credenciales / existente no). 37 total verdes.

## Frontend (sigue)
Falta ampliar el form mobile radicar con datos del cliente cuando NO hay sesión. Branch aparte.