### PR TITLE
fix: async credentials email so anon radicar doesnt hang on render

### DIFF
--- a/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/infrastructure/integraciones/correo/NotificadorCredencialesSmtp.java
+++ b/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/infrastructure/integraciones/correo/NotificadorCredencialesSmtp.java
@@ -3,11 +3,14 @@ package co.edu.konrad.pqrs.infrastructure.integraciones.correo;
 import co.edu.konrad.pqrs.domain.port.NotificadorCredenciales;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 /**
- * Envia las credenciales de acceso por SMTP de forma sincrona y best-effort:
- * si el correo falla o esta deshabilitado, el radicado sigue siendo valido.
+ * Envia las credenciales de acceso por SMTP de forma ASINCRONA y best-effort:
+ * el radicado responde de inmediato; si el correo falla, cuelga o esta
+ * deshabilitado, el radicado sigue siendo valido. Critico en Render free, que
+ * bloquea el SMTP saliente (sin async la request quedaba colgada ~138s).
  */
 @Component
 public class NotificadorCredencialesSmtp implements NotificadorCredenciales {
@@ -21,6 +24,7 @@ public class NotificadorCredencialesSmtp implements NotificadorCredenciales {
     }
 
     @Override
+    @Async
     public void enviarCredenciales(String email, String nombres, String clavePlana, String radicado) {
         if (!correo.habilitado()) {
             log.warn("SMTP deshabilitado — no se envian credenciales a {} (radicado {})", email, radicado);

--- a/Proyecto-Final/backend/pqrs/src/main/resources/application.yml
+++ b/Proyecto-Final/backend/pqrs/src/main/resources/application.yml
@@ -28,6 +28,10 @@ spring:
     properties:
       mail.smtp.auth: true
       mail.smtp.starttls.enable: true
+      # Timeouts cortos: Render free bloquea SMTP saliente; sin esto el envio cuelga ~138s.
+      mail.smtp.connectiontimeout: 7000
+      mail.smtp.timeout: 7000
+      mail.smtp.writetimeout: 7000
 
 server:
   port: ${PORT:8080}


### PR DESCRIPTION
## Problema
Radicar anónimo en prod tardaba ~138s y el front daba timeout ("Error al radicar"). Causa: el envío de credenciales SMTP era **síncrono** y Render free **bloquea el SMTP saliente** (puerto 587 cuelga ~138s). El radicado SÍ se creaba (201) pero la request quedaba colgada.

(Los 403 vistos en pruebas eran por reusar `numDoc` en tests → `duplicate key usuario_num_doc_key`, no relacionado.)

## Fix
- `NotificadorCredencialesSmtp.enviarCredenciales` ahora `@Async`: el radicado responde de inmediato; el correo se intenta en segundo plano, best-effort.
- Timeouts SMTP cortos (7s) en `application.yml`: si el envío cuelga, falla rápido sin acumular.

## Verificado
JDK 17 local: 37 tests verdes. Radicar responde rápido.

## Limitación conocida (Render free bloquea SMTP saliente)
El correo de credenciales NO se entregará en Render free (SMTP saliente bloqueado), aunque el radicado funcione. Mismo límite afecta al worker de notificaciones. Para entrega real de correo en prod: usar API HTTP de email (Brevo/SendGrid, puerto 443) o demo de correo en local. Decisión aparte.