### PR TITLE
feat: anonymous pqrs radication form in mobile

### DIFF
--- a/Proyecto-Final/frontend/pqrs-app/src/app/core/models/pqrs.model.ts
+++ b/Proyecto-Final/frontend/pqrs-app/src/app/core/models/pqrs.model.ts
@@ -88,6 +88,19 @@ export interface CrearPQRSRequest {
   descripcion: string;
 }
 
+/** Radicacion anonima: incluye datos del cliente para el registro automatico. */
+export interface CrearPQRSAnonimoRequest {
+  tipoDoc: string;   // CC | CE | TI | PP
+  numDoc: string;
+  nombres: string;
+  apellidos: string;
+  email: string;
+  telefono?: string;
+  tipo: string;      // peticion | queja | reclamo | sugerencia
+  asunto: string;
+  descripcion: string;
+}
+
 export interface ActualizarPQRSRequest {
   estado: string;
   justificacion: string;

--- a/Proyecto-Final/frontend/pqrs-app/src/app/core/services/pqrs.service.ts
+++ b/Proyecto-Final/frontend/pqrs-app/src/app/core/services/pqrs.service.ts
@@ -2,8 +2,9 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
-import { 
+import {
   CrearPQRSRequest,
+  CrearPQRSAnonimoRequest,
   PqrsResumen,
   PqrsDetalle,
   ActualizarPQRSRequest,
@@ -30,6 +31,19 @@ export class PQRSService {
     }
 
     return this.http.post<any>(this.apiUrl + '/pqrs', formData);
+  }
+
+  /**
+   * Radicacion anonima (sin login): el payload incluye los datos del cliente.
+   * El backend crea la cuenta si no existe y envia credenciales por correo.
+   */
+  crearPQRSAnonimo(payload: CrearPQRSAnonimoRequest, archivo?: File): Observable<any> {
+    const formData = new FormData();
+    formData.append('pqrs', new Blob([JSON.stringify(payload)], { type: 'application/json' }));
+    if (archivo) {
+      formData.append('anexo', archivo, archivo.name);
+    }
+    return this.http.post<any>(this.apiUrl + '/pqrs/anonimo', formData);
   }
 
   misRadicados(radicado?: string): Observable<PqrsResumen[]> {

--- a/Proyecto-Final/frontend/pqrs-app/src/app/mobile/radicar/radicar.page.html
+++ b/Proyecto-Final/frontend/pqrs-app/src/app/mobile/radicar/radicar.page.html
@@ -13,7 +13,45 @@
   </div>
 
   <form [formGroup]="radicacionForm" (ngSubmit)="onSubmit()">
-    
+
+    <div *ngIf="esAnonimo" class="mb-4 p-3 bg-blue-50 border border-blue-200 rounded-lg text-sm text-blue-800">
+      Radicas sin cuenta. Con tus datos crearemos un acceso y te enviaremos las credenciales al correo.
+    </div>
+
+    <ng-container *ngIf="esAnonimo">
+      <ion-item class="mb-4 rounded-lg border">
+        <ion-select formControlName="tipoDoc" label="Tipo de documento" label-placement="floating">
+          <ion-select-option value="CC">Cédula de ciudadanía</ion-select-option>
+          <ion-select-option value="CE">Cédula de extranjería</ion-select-option>
+          <ion-select-option value="TI">Tarjeta de identidad</ion-select-option>
+          <ion-select-option value="PP">Pasaporte</ion-select-option>
+        </ion-select>
+      </ion-item>
+
+      <ion-item class="mb-4 rounded-lg border">
+        <ion-input formControlName="numDoc" label="Número de documento" label-placement="floating"></ion-input>
+      </ion-item>
+
+      <ion-item class="mb-4 rounded-lg border">
+        <ion-input formControlName="nombres" label="Nombres" label-placement="floating"></ion-input>
+      </ion-item>
+
+      <ion-item class="mb-4 rounded-lg border">
+        <ion-input formControlName="apellidos" label="Apellidos" label-placement="floating"></ion-input>
+      </ion-item>
+
+      <ion-item class="mb-4 rounded-lg border">
+        <ion-input type="email" formControlName="email" label="Correo electrónico" label-placement="floating" placeholder="tucorreo@ejemplo.com"></ion-input>
+      </ion-item>
+      <div *ngIf="radicacionForm.get('email')?.invalid && radicacionForm.get('email')?.touched" class="text-red-600 text-sm mb-4 px-2">
+        Ingresa un correo válido (ahí recibirás tus credenciales y el radicado).
+      </div>
+
+      <ion-item class="mb-4 rounded-lg border">
+        <ion-input formControlName="telefono" label="Teléfono (opcional)" label-placement="floating"></ion-input>
+      </ion-item>
+    </ng-container>
+
     <ion-item class="mb-4 rounded-lg border">
       <ion-select formControlName="tipo" label="Tipo de Radicado" label-placement="floating">
         <ion-select-option value="peticion">Petición</ion-select-option>

--- a/Proyecto-Final/frontend/pqrs-app/src/app/mobile/radicar/radicar.page.ts
+++ b/Proyecto-Final/frontend/pqrs-app/src/app/mobile/radicar/radicar.page.ts
@@ -1,9 +1,10 @@
-﻿import { Component, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ToastController } from '@ionic/angular';
 import { PQRSService } from '../../core/services/pqrs.service';
-import { CrearPQRSRequest } from '../../core/models';
+import { AuthService } from '../../core/services/auth.service';
+import { CrearPQRSRequest, CrearPQRSAnonimoRequest } from '../../core/models';
 
 @Component({
   selector: 'app-radicar',
@@ -16,18 +17,34 @@ export class RadicarPage {
   isLoading = false;
   errorMessage = '';
   archivo: File | null = null;
+  esAnonimo = false;
 
   private formBuilder = inject(FormBuilder);
   private pqrsService = inject(PQRSService);
+  private authService = inject(AuthService);
   private router = inject(Router);
   private toastController = inject(ToastController);
 
   constructor() {
-    this.radicacionForm = this.formBuilder.group({
+    // Sin sesion -> radicacion anonima: pedimos tambien los datos del cliente.
+    this.esAnonimo = !this.authService.hasValidToken();
+
+    const grupo: Record<string, unknown> = {
       tipo: ['', [Validators.required]],
       asunto: ['', [Validators.required, Validators.minLength(5), Validators.maxLength(200)]],
       descripcion: ['', [Validators.required, Validators.minLength(20)]]
-    });
+    };
+
+    if (this.esAnonimo) {
+      grupo['tipoDoc'] = ['CC', [Validators.required]];
+      grupo['numDoc'] = ['', [Validators.required, Validators.maxLength(20)]];
+      grupo['nombres'] = ['', [Validators.required, Validators.maxLength(100)]];
+      grupo['apellidos'] = ['', [Validators.required, Validators.maxLength(100)]];
+      grupo['email'] = ['', [Validators.required, Validators.email]];
+      grupo['telefono'] = ['', [Validators.maxLength(20)]];
+    }
+
+    this.radicacionForm = this.formBuilder.group(grupo);
   }
 
   onArchivo(ev: Event) {
@@ -63,33 +80,59 @@ export class RadicarPage {
     this.isLoading = true;
     this.errorMessage = '';
 
-    const pqrsData: CrearPQRSRequest = {
-      tipo: this.radicacionForm.value.tipo,
-      asunto: this.radicacionForm.value.asunto.trim(),
-      descripcion: this.radicacionForm.value.descripcion.trim()
-    };
+    const peticion$ = this.esAnonimo
+      ? this.pqrsService.crearPQRSAnonimo(this.construirPayloadAnonimo(), this.archivo || undefined)
+      : this.pqrsService.crearPQRS(this.construirPayload(), this.archivo || undefined);
 
-    this.pqrsService.crearPQRS(pqrsData, this.archivo || undefined).subscribe({
+    peticion$.subscribe({
       next: async (response) => {
         this.isLoading = false;
-        
+        const mensaje = this.esAnonimo
+          ? 'PQRS radicada: ' + response.radicado + '. Te enviamos las credenciales al correo.'
+          : 'PQRS radicada exitosamente: ' + response.radicado;
         const toast = await this.toastController.create({
-          message: 'PQRS radicada exitosamente: ' + response.radicado,
-          duration: 3000,
+          message: mensaje,
+          duration: 4000,
           color: 'success',
           position: 'top'
         });
         await toast.present();
-        
+
         this.radicacionForm.reset();
         this.archivo = null;
-        this.router.navigate(['/mobile/historial']);
+        // Anonimo va a login (a usar sus nuevas credenciales); con sesion al historial.
+        this.router.navigate([this.esAnonimo ? '/mobile/login' : '/mobile/historial'],
+          this.esAnonimo ? { queryParams: { radicado: response.radicado } } : {});
       },
       error: (err) => {
         this.isLoading = false;
-        this.errorMessage = err.error?.message || 'Error al radicar la PQRS.';
+        this.errorMessage = err.error?.detalle || err.error?.message || 'Error al radicar la PQRS.';
         console.error('Error radicando PQRS:', err);
       }
     });
+  }
+
+  private construirPayload(): CrearPQRSRequest {
+    const v = this.radicacionForm.value;
+    return {
+      tipo: v.tipo,
+      asunto: v.asunto.trim(),
+      descripcion: v.descripcion.trim()
+    };
+  }
+
+  private construirPayloadAnonimo(): CrearPQRSAnonimoRequest {
+    const v = this.radicacionForm.value;
+    return {
+      tipoDoc: v.tipoDoc,
+      numDoc: v.numDoc.trim(),
+      nombres: v.nombres.trim(),
+      apellidos: v.apellidos.trim(),
+      email: v.email.trim(),
+      telefono: v.telefono?.trim() || undefined,
+      tipo: v.tipo,
+      asunto: v.asunto.trim(),
+      descripcion: v.descripcion.trim()
+    };
   }
 }


### PR DESCRIPTION
## Summary
Form de radicación anónima en mobile (sin login). Consume `POST /api/pqrs/anonimo`.

- Si NO hay sesión (`!hasValidToken()`): el form pide datos del cliente (tipoDoc, numDoc, nombres, apellidos, email, teléfono) además de la PQRS.
- Si hay sesión: flujo normal (`POST /api/pqrs`).
- Tras radicar anónimo → toast "te enviamos credenciales al correo" + navega a login con el radicado.
- `pqrs.service.crearPQRSAnonimo()` + modelo `CrearPQRSAnonimoRequest`.

Alineado a MVP func 2 (registro automático al radicar), no func 17 (registro manual).

## Depende de
Backend #108 (endpoint) + #109 (email async) — ya en develop.

## Test plan
- [ ] Sin login, /mobile/radicar → form con datos cliente → radica → 201 rápido