### PR TITLE
feat: brevo http email provider (works on render free)

### DIFF
--- a/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/infrastructure/integraciones/correo/CorreoBrevo.java
+++ b/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/infrastructure/integraciones/correo/CorreoBrevo.java
@@ -1,0 +1,60 @@
+package co.edu.konrad.pqrs.infrastructure.integraciones.correo;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Envia correos via la API HTTP de Brevo (POST https://api.brevo.com/v3/smtp/email).
+ * Usa el puerto 443, no bloqueado por Render free (a diferencia del SMTP saliente).
+ * Activo solo con correo.provider=brevo.
+ */
+@Component
+@ConditionalOnProperty(name = "correo.provider", havingValue = "brevo")
+public class CorreoBrevo implements EnviadorCorreo {
+
+    private static final Logger log = LoggerFactory.getLogger(CorreoBrevo.class);
+
+    private final RestClient http = RestClient.builder()
+            .baseUrl("https://api.brevo.com/v3")
+            .build();
+    private final String apiKey;
+    private final String fromEmail;
+    private final String fromNombre;
+
+    public CorreoBrevo(@Value("${brevo.api-key:}") String apiKey,
+                       @Value("${brevo.from-email:}") String fromEmail,
+                       @Value("${brevo.from-nombre:PQRS SuperMarket Konrad}") String fromNombre) {
+        this.apiKey = apiKey;
+        this.fromEmail = fromEmail;
+        this.fromNombre = fromNombre;
+    }
+
+    @Override
+    public boolean habilitado() {
+        return apiKey != null && !apiKey.isBlank() && fromEmail != null && !fromEmail.isBlank();
+    }
+
+    @Override
+    public void enviar(String destinatario, String asunto, String htmlBody) {
+        http.post()
+                .uri("/smtp/email")
+                .header("api-key", apiKey)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Map.of(
+                        "sender", Map.of("email", fromEmail, "name", fromNombre),
+                        "to", List.of(Map.of("email", destinatario)),
+                        "subject", asunto,
+                        "htmlContent", htmlBody))
+                .retrieve()
+                .toBodilessEntity();
+        log.info("Correo Brevo enviado a {} ({})", destinatario, asunto);
+    }
+}

--- a/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/infrastructure/integraciones/correo/CorreoSmtp.java
+++ b/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/infrastructure/integraciones/correo/CorreoSmtp.java
@@ -5,6 +5,7 @@ import jakarta.mail.internet.MimeMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
@@ -13,12 +14,13 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
 /**
- * Envia correos via SMTP (Gmail). Si MAIL_USERNAME esta ausente, queda deshabilitado
- * y el worker no procesa la cola. Sustituye a Resend (no requiere dominio verificado:
- * Gmail SMTP entrega a cualquier destinatario).
+ * Envia correos via SMTP (Gmail). Util en local; en Render free el SMTP saliente
+ * esta bloqueado, alli se usa CorreoBrevo (HTTP). Activo con correo.provider=smtp
+ * (por defecto) y si MAIL_USERNAME esta presente.
  */
 @Component
-public class CorreoSmtp {
+@ConditionalOnProperty(name = "correo.provider", havingValue = "smtp", matchIfMissing = true)
+public class CorreoSmtp implements EnviadorCorreo {
 
     private static final Logger log = LoggerFactory.getLogger(CorreoSmtp.class);
 
@@ -37,11 +39,12 @@ public class CorreoSmtp {
         this.fromNombre = fromNombre;
     }
 
+    @Override
     public boolean habilitado() {
         return username != null && !username.isBlank();
     }
 
-    /** Envia HTML. Lanza excepcion si falla (el scheduler cuenta el intento). */
+    @Override
     public void enviar(String destinatario, String asunto, String htmlBody) {
         try {
             MimeMessage msg = mailSender.createMimeMessage();

--- a/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/infrastructure/integraciones/correo/EnviadorCorreo.java
+++ b/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/infrastructure/integraciones/correo/EnviadorCorreo.java
@@ -1,0 +1,13 @@
+package co.edu.konrad.pqrs.infrastructure.integraciones.correo;
+
+/**
+ * Abstraccion de envio de correo. Implementaciones: SMTP (local) y Brevo HTTP
+ * (produccion en Render, que bloquea el SMTP saliente). Se selecciona con
+ * la propiedad correo.provider (smtp por defecto, brevo en prod).
+ */
+public interface EnviadorCorreo {
+
+    boolean habilitado();
+
+    void enviar(String destinatario, String asunto, String htmlBody);
+}

--- a/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/infrastructure/integraciones/correo/NotificadorCredencialesSmtp.java
+++ b/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/infrastructure/integraciones/correo/NotificadorCredencialesSmtp.java
@@ -17,9 +17,9 @@ public class NotificadorCredencialesSmtp implements NotificadorCredenciales {
 
     private static final Logger log = LoggerFactory.getLogger(NotificadorCredencialesSmtp.class);
 
-    private final CorreoSmtp correo;
+    private final EnviadorCorreo correo;
 
-    public NotificadorCredencialesSmtp(CorreoSmtp correo) {
+    public NotificadorCredencialesSmtp(EnviadorCorreo correo) {
         this.correo = correo;
     }
 

--- a/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/infrastructure/integraciones/resend/ProcesadorNotificaciones.java
+++ b/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/infrastructure/integraciones/resend/ProcesadorNotificaciones.java
@@ -1,6 +1,6 @@
 package co.edu.konrad.pqrs.infrastructure.integraciones.resend;
 
-import co.edu.konrad.pqrs.infrastructure.integraciones.correo.CorreoSmtp;
+import co.edu.konrad.pqrs.infrastructure.integraciones.correo.EnviadorCorreo;
 import co.edu.konrad.pqrs.infrastructure.persistencia.NotificacionEntidad;
 import co.edu.konrad.pqrs.infrastructure.persistencia.NotificacionJpaRepositorio;
 import co.edu.konrad.pqrs.infrastructure.persistencia.UsuarioEntidad;
@@ -26,11 +26,11 @@ public class ProcesadorNotificaciones {
 
     private final NotificacionJpaRepositorio notificaciones;
     private final UsuarioJpaRepositorio usuarios;
-    private final CorreoSmtp correo;
+    private final EnviadorCorreo correo;
 
     public ProcesadorNotificaciones(NotificacionJpaRepositorio notificaciones,
                                     UsuarioJpaRepositorio usuarios,
-                                    CorreoSmtp correo) {
+                                    EnviadorCorreo correo) {
         this.notificaciones = notificaciones;
         this.usuarios = usuarios;
         this.correo = correo;

--- a/Proyecto-Final/backend/pqrs/src/main/resources/application.yml
+++ b/Proyecto-Final/backend/pqrs/src/main/resources/application.yml
@@ -48,8 +48,14 @@ jwt:
   expiration-ms: 28800000   # 8 horas
 
 correo:
-  from: ${MAIL_FROM:${MAIL_USERNAME:}}   # remitente; por defecto el usuario SMTP
+  provider: ${CORREO_PROVIDER:smtp}      # smtp (local) | brevo (prod, HTTP API)
+  from: ${MAIL_FROM:${MAIL_USERNAME:}}   # remitente SMTP; por defecto el usuario SMTP
   from-nombre: ${MAIL_FROM_NOMBRE:PQRS SuperMarket Konrad}
+
+brevo:
+  api-key: ${BREVO_API_KEY:}             # API key Brevo (HTTP, no bloqueado por Render)
+  from-email: ${BREVO_FROM_EMAIL:}       # sender verificado en Brevo
+  from-nombre: ${BREVO_FROM_NOMBRE:PQRS SuperMarket Konrad}
 
 r2:
   enabled: ${R2_ENABLED:false}         # true cuando haya credenciales Cloudflare R2


### PR DESCRIPTION
## Summary
Render free bloquea SMTP saliente → correos no llegan en prod. Agrego proveedor **Brevo (HTTP API, puerto 443)** seleccionable por config.

- `EnviadorCorreo` interfaz; impls `CorreoSmtp` (local) y `CorreoBrevo` (prod HTTP).
- Selección por `correo.provider` (smtp por defecto, brevo en prod).
- Worker de notificaciones + envío de credenciales usan la interfaz.
- Brevo: free 300/día, sender verificado sin dominio, POST /v3/smtp/email.

## Env vars Render (a configurar)
- `CORREO_PROVIDER=brevo`
- `BREVO_API_KEY=xkeysib-...`
- `BREVO_FROM_EMAIL=<sender verificado>`

## Tests
37 verdes (JDK 17).

## Pendiente
Cuenta Brevo + API key + sender verificado (usuario). Luego configurar Render + verificar entrega real.