### PR TITLE
fix: notify client on pqrs state change

### DIFF
--- a/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/domain/service/ServicioTramitar.java
+++ b/Proyecto-Final/backend/pqrs/src/main/java/co/edu/konrad/pqrs/domain/service/ServicioTramitar.java
@@ -3,6 +3,7 @@ package co.edu.konrad.pqrs.domain.service;
 import co.edu.konrad.pqrs.domain.model.EstadoPqrs;
 import co.edu.konrad.pqrs.domain.model.Pqrs;
 import co.edu.konrad.pqrs.domain.model.Tramite;
+import co.edu.konrad.pqrs.domain.port.NotificadorPort;
 import co.edu.konrad.pqrs.domain.port.PqrsRepositorio;
 import co.edu.konrad.pqrs.domain.port.TramiteRepositorio;
 import co.edu.konrad.pqrs.infrastructure.auditoria.Auditable;
@@ -16,10 +17,14 @@ public class ServicioTramitar {
 
     private final PqrsRepositorio pqrsRepositorio;
     private final TramiteRepositorio tramiteRepositorio;
+    private final NotificadorPort notificador;
 
-    public ServicioTramitar(PqrsRepositorio pqrsRepositorio, TramiteRepositorio tramiteRepositorio) {
+    public ServicioTramitar(PqrsRepositorio pqrsRepositorio,
+                            TramiteRepositorio tramiteRepositorio,
+                            NotificadorPort notificador) {
         this.pqrsRepositorio = pqrsRepositorio;
         this.tramiteRepositorio = tramiteRepositorio;
+        this.notificador = notificador;
     }
 
     public static class PqrsNoEncontradaException extends RuntimeException {
@@ -46,6 +51,11 @@ public class ServicioTramitar {
         if (nuevoEstado.esCierre()) {
             pqrs.setFechaCierre(LocalDateTime.now());
         }
-        return pqrsRepositorio.guardar(pqrs);
+        Pqrs guardada = pqrsRepositorio.guardar(pqrs);
+
+        // Notifica al cliente el cambio de estado (worker async lo envia por correo).
+        notificador.encolar(guardada.getClienteId(), guardada.getId(), "cambio_estado", "pqrs-cambio-estado");
+
+        return guardada;
     }
 }

--- a/Proyecto-Final/backend/pqrs/src/test/java/co/edu/konrad/pqrs/domain/service/ServicioTramitarTest.java
+++ b/Proyecto-Final/backend/pqrs/src/test/java/co/edu/konrad/pqrs/domain/service/ServicioTramitarTest.java
@@ -3,6 +3,7 @@ package co.edu.konrad.pqrs.domain.service;
 import co.edu.konrad.pqrs.domain.model.EstadoPqrs;
 import co.edu.konrad.pqrs.domain.model.Pqrs;
 import co.edu.konrad.pqrs.domain.model.TipoPqrs;
+import co.edu.konrad.pqrs.domain.port.NotificadorPort;
 import co.edu.konrad.pqrs.domain.port.PqrsRepositorio;
 import co.edu.konrad.pqrs.domain.port.TramiteRepositorio;
 import co.edu.konrad.pqrs.domain.service.ServicioTramitar.PqrsNoEncontradaException;
@@ -14,19 +15,23 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 class ServicioTramitarTest {
 
     private PqrsRepositorio pqrsRepo;
     private TramiteRepositorio tramiteRepo;
+    private NotificadorPort notificador;
     private ServicioTramitar servicio;
 
     @BeforeEach
     void setup() {
         pqrsRepo = Mockito.mock(PqrsRepositorio.class);
         tramiteRepo = Mockito.mock(TramiteRepositorio.class);
-        servicio = new ServicioTramitar(pqrsRepo, tramiteRepo);
+        notificador = Mockito.mock(NotificadorPort.class);
+        servicio = new ServicioTramitar(pqrsRepo, tramiteRepo, notificador);
         when(pqrsRepo.guardar(any())).thenAnswer(inv -> inv.getArgument(0));
     }
 
@@ -46,6 +51,7 @@ class ServicioTramitarTest {
         assertEquals(2, r.getGestorId());
         assertNull(r.getFechaCierre());
         verify(tramiteRepo).guardar(any());
+        verify(notificador).encolar(eq(3), eq(10), eq("cambio_estado"), anyString());
     }
 
     @Test


### PR DESCRIPTION
## Problema
Al tramitar (cambiar estado), el front dice "Se notificará al cliente por correo" pero el backend NUNCA encolaba la notificación → no llegaba correo. Solo radicar notificaba.

## Fix
`ServicioTramitar.tramitar` ahora encola `cambio_estado` al cliente tras guardar. El worker async (ProcesadorNotificaciones) ya maneja ese tipo y lo envía via Brevo.

## Tests
37 verdes. Test verifica `notificador.encolar(clienteId, pqrsId, "cambio_estado", ...)`.